### PR TITLE
Add `partition` operator

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,10 +15,7 @@ jobs:
       with:
         name: build-logs-${{ github.run_id }}
         path: logs
-    - uses: codecov/codecov-action@v1.0.5
-      with:
-        token: 1519d58c-6fb9-483f-af6c-7f6f0b384345
-        name: CombineExt
+
   iOS:
     name: "iOS"
     runs-on: macOS-latest
@@ -27,6 +24,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Run tests
       run: set -o pipefail && xcodebuild -project CombineExt.xcodeproj -scheme CombineExt-Package -enableCodeCoverage YES -sdk iphonesimulator -destination "name=iPhone 11" test | xcpretty -c -r html --output logs/iOS.html
+    - uses: codecov/codecov-action@v1.0.5
+      with:
+        token: 1519d58c-6fb9-483f-af6c-7f6f0b384345
+        name: CombineExt
     - uses: actions/upload-artifact@v1
       with:
         name: build-logs-${{ github.run_id }}

--- a/CombineExt.xcodeproj/project.pbxproj
+++ b/CombineExt.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		78002BBB241E97350018AA28 /* CurrentValueRelayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78002BBA241E97350018AA28 /* CurrentValueRelayTests.swift */; };
 		78988A1E241EAFDD00F3A4AF /* PassthroughRelayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78988A1D241EAFDD00F3A4AF /* PassthroughRelayTests.swift */; };
 		78988A20241EB0FE00F3A4AF /* CombineExt.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "CombineExt::CombineExt::Product" /* CombineExt.framework */; };
+		78988A23241FFE2400F3A4AF /* Partition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78988A22241FFE2400F3A4AF /* Partition.swift */; };
+		78988A25241FFE2E00F3A4AF /* PartitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78988A24241FFE2E00F3A4AF /* PartitionTests.swift */; };
 		78AA9297241B8532009BD68B /* AssignToManyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78AA9296241B8532009BD68B /* AssignToManyTests.swift */; };
 		78AA9299241B8C45009BD68B /* DemandBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78AA9298241B8C45009BD68B /* DemandBuffer.swift */; };
 		78C193CF241C16C40001B7FD /* FlatMapLatest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78C193CE241C16C40001B7FD /* FlatMapLatest.swift */; };
@@ -61,6 +63,8 @@
 		78002BB8241E91D70018AA28 /* PassthroughRelay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassthroughRelay.swift; sourceTree = "<group>"; };
 		78002BBA241E97350018AA28 /* CurrentValueRelayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentValueRelayTests.swift; sourceTree = "<group>"; };
 		78988A1D241EAFDD00F3A4AF /* PassthroughRelayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassthroughRelayTests.swift; sourceTree = "<group>"; };
+		78988A22241FFE2400F3A4AF /* Partition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Partition.swift; sourceTree = "<group>"; };
+		78988A24241FFE2E00F3A4AF /* PartitionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PartitionTests.swift; sourceTree = "<group>"; };
 		78AA9296241B8532009BD68B /* AssignToManyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignToManyTests.swift; sourceTree = "<group>"; };
 		78AA9298241B8C45009BD68B /* DemandBuffer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DemandBuffer.swift; sourceTree = "<group>"; };
 		78C193CE241C16C40001B7FD /* FlatMapLatest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlatMapLatest.swift; sourceTree = "<group>"; };
@@ -145,6 +149,7 @@
 				78C193DF241D4D8D0001B7FD /* MaterializeTests.swift */,
 				78C193E3241D63620001B7FD /* DematerializeTests.swift */,
 				78002BBA241E97350018AA28 /* CurrentValueRelayTests.swift */,
+				78988A24241FFE2E00F3A4AF /* PartitionTests.swift */,
 				78988A1D241EAFDD00F3A4AF /* PassthroughRelayTests.swift */,
 			);
 			path = Tests;
@@ -190,6 +195,7 @@
 				78C193CE241C16C40001B7FD /* FlatMapLatest.swift */,
 				78C193D3241C2DE00001B7FD /* Create.swift */,
 				78C193DD241D46F40001B7FD /* Materialize.swift */,
+				78988A22241FFE2400F3A4AF /* Partition.swift */,
 				78C193E1241D596F0001B7FD /* Dematerialize.swift */,
 			);
 			path = Operators;
@@ -306,6 +312,7 @@
 				78C193E2241D596F0001B7FD /* Dematerialize.swift in Sources */,
 				78002BB7241E915E0018AA28 /* CurrentValueRelay.swift in Sources */,
 				78C193DE241D46F40001B7FD /* Materialize.swift in Sources */,
+				78988A23241FFE2400F3A4AF /* Partition.swift in Sources */,
 				78C193D4241C2DE00001B7FD /* Create.swift in Sources */,
 				OBJ_22 /* AssignToMany.swift in Sources */,
 				78C193D7241C2E580001B7FD /* Event.swift in Sources */,
@@ -328,6 +335,7 @@
 			files = (
 				78C193D2241C1B750001B7FD /* FlatMapLatestTests.swift in Sources */,
 				78AA9297241B8532009BD68B /* AssignToManyTests.swift in Sources */,
+				78988A25241FFE2E00F3A4AF /* PartitionTests.swift in Sources */,
 				OBJ_41 /* WithLatestFromTests.swift in Sources */,
 				78C193E0241D4D8D0001B7FD /* MaterializeTests.swift in Sources */,
 				78002BBB241E97350018AA28 /* CurrentValueRelayTests.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -236,6 +236,37 @@ Converts a previously-materialized publisher into its original form. Given a `Pu
 
 **Note**: This operator only works on publishers that were materialized with the `materialize()` operator.
 
+------
+
+### partition
+
+Partition a publisher's values into two separate publishers of values that match, and don't match, the provided predicate.
+
+```swift
+let source = PassthroughSubject<Int, Never>()
+
+let (even, odd) = source.partition { $0 % 2 == 0 }
+
+even.sink(receiveValue: { print("even: \($0)") })
+odd.sink(receiveValue: { print("odd: \($0)") })
+
+source.send(1)
+source.send(2)
+source.send(3)
+source.send(4)
+source.send(5)
+```
+
+#### Output:
+
+```none
+odd: 1
+even: 2
+odd: 3
+even: 4
+odd: 5
+```
+
 ## Publishers
 
 This section outlines some of the custom Combine publishers CombineExt provides

--- a/Sources/Operators/Partition.swift
+++ b/Sources/Operators/Partition.swift
@@ -1,0 +1,30 @@
+//
+//  Partition.swift
+//  CombineExt
+//
+//  Created by Shai Mishali on 14/03/2020.
+//  Copyright © 2020 Combine Community. All rights reserved.
+//
+
+import Combine
+
+public extension Publisher {
+    /// A partitioned publisher
+    typealias Partition = AnyPublisher<Output, Failure>
+
+    /// Partition a publisher's values into two separate publishers of values that match, and don't match, the provided predicate.
+    ///
+    /// - parameter predicate: A predicate used to filter matching and non-matching values.
+    ///
+    /// - returns: A tuple of two publishers of values that match, and don't match, the provided predicate.
+    ///
+    /// - note: The source publisher is `share()`d by default so resources are shared between the partitioned publshers
+    func partition(_ predicate: @escaping (Output) -> Bool) -> (matches: Partition, nonMatches: Partition) {
+        let source = map { ($0, predicate($0)) }.share()
+
+        let hits = source.compactMap { $0.1 ? $0.0 : nil }.eraseToAnyPublisher()
+        let misses = source.compactMap { !$0.1 ? $0.0 : nil }.eraseToAnyPublisher()
+
+        return (hits, misses)
+    }
+}

--- a/Tests/PartitionTests.swift
+++ b/Tests/PartitionTests.swift
@@ -1,0 +1,57 @@
+//
+//  WithLatestFrom.swift
+//  CombineExtTests
+//
+//  Created by Shai Mishali on 24/10/2019.
+//  Copyright © 2020 Combine Community. All rights reserved.
+//
+
+import XCTest
+import Combine
+import CombineExt
+
+class PartitionTests: XCTestCase {
+    var source = PassthroughRelay<Int>()
+    var evenSub: AnyCancellable!
+    var oddSub: AnyCancellable!
+
+    override func setUp() {
+        source = .init()
+        evenSub = nil
+        oddSub = nil
+    }
+
+    func testPartitionBothMatch() {
+        let (evens, odds) = source.partition { $0 % 2 == 0 }
+        var evenValues = [Int]()
+        var oddValues = [Int]()
+
+        evenSub = evens
+            .sink(receiveValue: { evenValues.append($0) })
+
+        oddSub = odds
+            .sink(receiveValue: { oddValues.append($0) })
+
+        (0...10).forEach { source.accept($0) }
+
+        XCTAssertEqual([1, 3, 5, 7, 9], oddValues)
+        XCTAssertEqual([0, 2, 4, 6, 8, 10], evenValues)
+    }
+
+    func testPartitionOneSideMatch() {
+        let (all, none) = source.partition { $0 <= 10 }
+        var allValues = [Int]()
+        var noneValues = [Int]()
+
+        evenSub = all
+            .sink(receiveValue: { allValues.append($0) })
+
+        oddSub = none
+            .sink(receiveValue: { noneValues.append($0) })
+
+        (0...10).forEach { source.accept($0) }
+
+        XCTAssertEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], allValues)
+        XCTAssertTrue(noneValues.isEmpty)
+    }
+}


### PR DESCRIPTION
Partition a publisher's values into two separate publishers of values that match, and don't match, the provided predicate.

```swift
let source = PassthroughSubject<Int, Never>()

let (even, odd) = source.partition { $0 % 2 == 0 }

even.sink(receiveValue: { print("even: \($0)") })
odd.sink(receiveValue: { print("odd: \($0)") })

source.send(1)
source.send(2)
source.send(3)
source.send(4)
source.send(5)
```

#### Output:

```none
odd: 1
even: 2
odd: 3
even: 4
odd: 5
```