### PR TITLE
First pass at `Publisher.removeAllDuplicates` and `removeAllDuplicates(by:)`.

### DIFF
--- a/CombineExt.xcodeproj/project.pbxproj
+++ b/CombineExt.xcodeproj/project.pbxproj
@@ -47,6 +47,8 @@
 		AAEAF0E92436D785007C35E0 /* SetOutputTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEAF0E82436D785007C35E0 /* SetOutputTypeTests.swift */; };
 		BF50924B241FFE8E00600DF4 /* ZipManyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF50924A241FFE8E00600DF4 /* ZipManyTests.swift */; };
 		BF8121BC241FF42C006A93B8 /* ZipMany.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8121BB241FF42C006A93B8 /* ZipMany.swift */; };
+		BF84B7412426B786001BFA88 /* RemoveAllDuplicates.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF84B7402426B786001BFA88 /* RemoveAllDuplicates.swift */; };
+		BF84B7432426C332001BFA88 /* RemoveAllDuplicatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF84B7422426C332001BFA88 /* RemoveAllDuplicatesTests.swift */; };
 		BFB4EA132428256B0096E9E9 /* CombineLatestMany.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFB4EA122428256B0096E9E9 /* CombineLatestMany.swift */; };
 		BFB4EA1524283ECF0096E9E9 /* CombineLatestManyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFB4EA1424283ECF0096E9E9 /* CombineLatestManyTests.swift */; };
 		DC16910F24281A1800B234C4 /* MapMany.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC16910E24281A1800B234C4 /* MapMany.swift */; };
@@ -93,6 +95,8 @@
 		AAEAF0E82436D785007C35E0 /* SetOutputTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetOutputTypeTests.swift; sourceTree = "<group>"; };
 		BF50924A241FFE8E00600DF4 /* ZipManyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZipManyTests.swift; sourceTree = "<group>"; };
 		BF8121BB241FF42C006A93B8 /* ZipMany.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZipMany.swift; sourceTree = "<group>"; };
+		BF84B7402426B786001BFA88 /* RemoveAllDuplicates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveAllDuplicates.swift; sourceTree = "<group>"; };
+		BF84B7422426C332001BFA88 /* RemoveAllDuplicatesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveAllDuplicatesTests.swift; sourceTree = "<group>"; };
 		BFB4EA122428256B0096E9E9 /* CombineLatestMany.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineLatestMany.swift; sourceTree = "<group>"; };
 		BFB4EA1424283ECF0096E9E9 /* CombineLatestManyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineLatestManyTests.swift; sourceTree = "<group>"; };
 		"CombineExt::CombineExt::Product" /* CombineExt.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = CombineExt.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -176,6 +180,7 @@
 				DC1691112428228200B234C4 /* MapManyTests.swift */,
 				AAEAF0E82436D785007C35E0 /* SetOutputTypeTests.swift */,
 				788CD8F4242F9DFB0015B3C7 /* AmbTests.swift */,
+				BF84B7422426C332001BFA88 /* RemoveAllDuplicatesTests.swift */,
 			);
 			path = Tests;
 			sourceTree = SOURCE_ROOT;
@@ -227,6 +232,7 @@
 				DC16910E24281A1800B234C4 /* MapMany.swift */,
 				AAEAF0E62436D346007C35E0 /* SetOutputType.swift */,
 				788CD8FA2431228C0015B3C7 /* Amb.swift */,
+				BF84B7402426B786001BFA88 /* RemoveAllDuplicates.swift */,
 			);
 			path = Operators;
 			sourceTree = "<group>";
@@ -346,6 +352,7 @@
 				78C193DE241D46F40001B7FD /* Materialize.swift in Sources */,
 				78988A23241FFE2400F3A4AF /* Partition.swift in Sources */,
 				BF8121BC241FF42C006A93B8 /* ZipMany.swift in Sources */,
+				BF84B7412426B786001BFA88 /* RemoveAllDuplicates.swift in Sources */,
 				78C193D4241C2DE00001B7FD /* Create.swift in Sources */,
 				OBJ_22 /* AssignToMany.swift in Sources */,
 				AAEAF0E72436D346007C35E0 /* SetOutputType.swift in Sources */,
@@ -374,6 +381,7 @@
 				AAEAF0E92436D785007C35E0 /* SetOutputTypeTests.swift in Sources */,
 				78988A25241FFE2E00F3A4AF /* PartitionTests.swift in Sources */,
 				OBJ_41 /* WithLatestFromTests.swift in Sources */,
+				BF84B7432426C332001BFA88 /* RemoveAllDuplicatesTests.swift in Sources */,
 				78C193E0241D4D8D0001B7FD /* MaterializeTests.swift in Sources */,
 				78002BBB241E97350018AA28 /* CurrentValueRelayTests.swift in Sources */,
 				78C193E4241D63620001B7FD /* DematerializeTests.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -28,10 +28,12 @@ All operators, utilities and helpers respect Combine's publisher contract, inclu
 * [values](#values)
 * [failures](#failures)
 * [dematerialize](#dematerialize)
+* [partition](#partition)
 * [zip(with:) and Collection.zip](#ZipMany)
 * [combineLatest(with:) and Collection.combineLatest](#CombineLatestMany)
 * [mapMany(_:)](#MapMany)
 * [setOutputType(to:)](#setOutputType)
+* [removeAllDuplicates and removeAllDuplicates(by:) ](#removeAllDuplicates)
 
 ### Publishers
 * [AnyPublisher.create](#AnypublisherCreate)
@@ -312,7 +314,7 @@ odd: 5
 
 This repo includes two overloads on Combine’s `Publisher.zip` methods (which, at the time of writing only go up to arity three).
 
-This lets you arbitrarily zip many publishers and receive either an array of inner publisher outputs back.
+This lets you arbitrarily zip many publishers and receive an array of inner publisher outputs back.
 
 ```swift
 let first = PassthroughSubject<Int, Never>()
@@ -377,7 +379,6 @@ combineLatest: [true, true, true, true]
 combineLatest: [false, true, true, true]
 ```
 
-
 ### MapMany
 
 Projects each element of a publisher collection into a new publisher collection form.
@@ -401,6 +402,25 @@ intArrayPublisher.send([10, 2, 2, 4, 3, 8])
 ### setOutputType
 
 `Publisher.setOutputType(to:)` is an analog to [`.setFailureType(to:)`](https://developer.apple.com/documentation/combine/publisher/3204753-setfailuretype) for when `Output` is constrained to `Never`. This is especially helpful when chaining operators after an [`.ignoreOutput()`](https://developer.apple.com/documentation/combine/publisher/3204714-ignoreoutput) call.
+
+### removeAllDuplicates
+
+`Publisher.removeAllDuplicates` and `.removeAllDuplicates(by:)` are stricter forms of Apple’s [`Publisher.removeDuplicates`](https://developer.apple.com/documentation/combine/publisher/3204745-removeduplicates) and [`.removeDuplicates(by:)`](https://developer.apple.com/documentation/combine/publisher/3204746-removeduplicates)—the operators de-duplicate across _all_ previous value events, instead of pairwise.
+
+If your `Output` doesn‘t conform to `Hashable` or `Equatable`, you may instead use the predicate-based version of this operator to decide whether two elements are equal.
+
+```swift
+subscription = [1, 1, 2, 1, 3, 3, 4].publisher
+  .removeAllDuplicates()
+  .sink(receiveValue: { print("removeAllDuplicates: \($0)") })
+```
+
+```none
+removeAllDuplicates: 1
+removeAllDuplicates: 2
+removeAllDuplicates: 3
+removeAllDuplicates: 4
+```
 
 ## Publishers
 

--- a/Sources/Operators/RemoveAllDuplicates.swift
+++ b/Sources/Operators/RemoveAllDuplicates.swift
@@ -1,0 +1,63 @@
+//
+//  RemoveAllDuplicates.swift
+//  CombineExt
+//
+//  Created by Jasdev Singh on 21/03/2020.
+//  Copyright © 2020 Combine Community. All rights reserved.
+//
+
+import Combine
+
+public extension Publisher where Output: Hashable {
+    /// De-duplicates _all_ published value events, as opposed
+    /// to pairwise with `Publisher.removeDuplicates`.
+    ///
+    /// - note: It’s important to note that this operator stores all emitted values
+    ///         in an in-memory `Set`. So, use this operator with caution, when handling publishers
+    ///         that emit a large number of unique value events.
+    ///
+    /// - returns: A publisher that consumes duplicate values across all previous emissions from upstream.
+    func removeAllDuplicates() -> Publishers.Filter<Self> {
+        var seen = Set<Output>()
+        return filter { incoming in seen.insert(incoming).inserted }
+    }
+}
+
+public extension Publisher where Output: Equatable {
+    /// `Publisher.removeAllDuplicates` de-duplicates _all_ published `Hashable`-conforming value events, as opposed to pairwise with `Publisher.removeDuplicates`.
+    ///
+    /// - note: It’s important to note that this operator stores all emitted values in an in-memory `Array`. So, use
+    ///         this operator with caution, when handling publishers that emit a large number of unique value events.
+    ///
+    /// - returns: A publisher that consumes duplicate values across all previous emissions from upstream.
+    func removeAllDuplicates() -> Publishers.Filter<Self> {
+        removeAllDuplicates(by: ==)
+    }
+}
+
+public extension Publisher {
+    /// De-duplicates _all_ published value events, along the provided `by` predicate, as opposed to pairwise with `Publisher.removeDuplicates(by:)`.
+    ///
+    /// - parameter by: A predicate to use when determining uniqueness. `Publisher.removeAllDuplicates` will iterate
+    ///                 over all seen values applying each known unique value as the first argument to the predicate and the
+    ///                 incoming value event as the second, i.e. `by(see, next) -> Bool`. If this predicate is `true` for any
+    ///                 seen value, the next incoming value isn’t emitted downstream.
+    ///
+    /// - note: It’s important to note that this operator stores all emitted values
+    ///         in an in-memory `Array`. So, use this operator with caution, when handling publishers
+    ///         that emit a large number of unique value events (as per `by`).
+    ///
+    /// - returns: A publisher that consumes duplicate values across all previous emissions from upstream
+    ///            (signaled with `by`).
+    func removeAllDuplicates(by comparator: @escaping (Output, Output) -> Bool) -> Publishers.Filter<Self> {
+        var seen = [Output]()
+        return filter { incoming in
+            if seen.contains(where: { comparator($0, incoming) }) {
+                return false
+            } else {
+                seen.append(incoming)
+                return true
+            }
+        }
+    }
+}

--- a/Tests/RemoveAllDuplicatesTests.swift
+++ b/Tests/RemoveAllDuplicatesTests.swift
@@ -1,0 +1,233 @@
+//
+//  RemoveAllDuplicatesTests.swift
+//  CombineExtTests
+//
+//  Created by Jasdev Singh on 21/03/2020.
+//  Copyright © 2020 Combine Community. All rights reserved.
+//
+
+import Combine
+import CombineExt
+import XCTest
+
+final class RemoveAllDuplicatesTests: XCTestCase {
+    private var subscription: AnyCancellable!
+
+    private enum RemoveAllDuplicatesTestError: Error {
+        case anError
+    }
+
+    // MARK: - `Hashable`-related tests
+
+    private struct HashableFour: Hashable {
+        static let one = HashableFour(1)
+        static let two = HashableFour(2)
+        static let three = HashableFour(3)
+        static let four = HashableFour(4)
+
+        private let underlying: Int
+
+        private init(_ underlying: Int) { self.underlying = underlying }
+    }
+
+    func testHashableExpectedDeduplication() {
+        var results = [HashableFour]()
+
+        subscription = [.one, .one, .two, .one, .three, .three, .four].publisher
+            .removeAllDuplicates()
+            .sink(receiveValue: { results.append($0) })
+
+        XCTAssertEqual(results, [.one, .two, .three, .four])
+    }
+
+    func testHashableDeduplicationWithNoDuplicates() {
+        var results = [HashableFour]()
+
+        subscription = [.one, .two, .three, .four].publisher
+            .removeAllDuplicates()
+            .sink(receiveValue: { results.append($0) })
+
+        XCTAssertEqual(results, [.one, .two, .three, .four])
+    }
+
+    func testHashableDeduplicationDoesntInterfereWithFinishEvents() {
+        let integers = PassthroughSubject<HashableFour, Never>()
+
+        var completion: Subscribers.Completion<Never>?
+        var results = [HashableFour]()
+
+        subscription = integers
+            .removeAllDuplicates()
+            .sink(receiveCompletion: { completion = $0 },
+                  receiveValue: { results.append($0) })
+
+        integers.send(.one)
+        integers.send(.two)
+        integers.send(.three)
+        integers.send(.four)
+        integers.send(completion: .finished)
+
+        XCTAssertEqual(results, [.one, .two, .three, .four])
+        XCTAssertEqual(completion, .finished)
+    }
+
+    func testHashableDeduplicationDoesntInterfereWithErrorEvents() {
+        let integers = PassthroughSubject<HashableFour, RemoveAllDuplicatesTestError>()
+
+        var completion: Subscribers.Completion<RemoveAllDuplicatesTestError>?
+        var results = [HashableFour]()
+
+        subscription = integers
+            .removeAllDuplicates()
+            .sink(receiveCompletion: { completion = $0 },
+                  receiveValue: { results.append($0) })
+
+        integers.send(.one)
+        integers.send(.two)
+        integers.send(.three)
+        integers.send(.four)
+        integers.send(completion: .failure(.anError))
+
+        XCTAssertEqual(results, [.one, .two, .three, .four])
+        XCTAssertEqual(completion, .failure(.anError))
+    }
+
+    // MARK: - `Equatable`-related tests
+
+    private struct EquatableFour: Equatable {
+        static let one = EquatableFour(1)
+        static let two = EquatableFour(2)
+        static let three = EquatableFour(3)
+        static let four = EquatableFour(4)
+
+        private let underlying: Int
+
+        private init(_ underlying: Int) { self.underlying = underlying }
+    }
+
+    func testEquatableExpectedDeduplication() {
+        var results = [EquatableFour]()
+
+        subscription = [EquatableFour.one, .one, .two, .one, .three, .three, .four].publisher
+            .removeAllDuplicates()
+            .sink(receiveValue: { results.append($0) })
+
+        XCTAssertEqual(results, [.one, .two, .three, .four])
+    }
+
+    func testEquatableDeduplicationWithNoDuplicates() {
+        var results = [EquatableFour]()
+
+        subscription = [EquatableFour.one, .two, .three, .four].publisher
+            .removeAllDuplicates()
+            .sink(receiveValue: { results.append($0) })
+
+        XCTAssertEqual(results, [.one, .two, .three, .four])
+    }
+
+    func testEquatableDeduplicationDoesntInterfereWithFinishEvents() {
+        let fours = PassthroughSubject<EquatableFour, Never>()
+
+        var completion: Subscribers.Completion<Never>?
+        var results = [EquatableFour]()
+
+        subscription = fours
+            .removeAllDuplicates()
+            .sink(receiveCompletion: { completion = $0 },
+                  receiveValue: { results.append($0) })
+
+        fours.send(.one)
+        fours.send(.two)
+        fours.send(.three)
+        fours.send(.four)
+        fours.send(completion: .finished)
+
+        XCTAssertEqual(results, [.one, .two, .three, .four])
+        XCTAssertEqual(completion, .finished)
+    }
+
+    func testEquatableDeduplicationDoesntInterfereWithErrorEvents() {
+        let fours = PassthroughSubject<EquatableFour, RemoveAllDuplicatesTestError>()
+
+        var completion: Subscribers.Completion<RemoveAllDuplicatesTestError>?
+        var results = [EquatableFour]()
+
+        subscription = fours
+            .removeAllDuplicates()
+            .sink(receiveCompletion: { completion = $0 },
+                  receiveValue: { results.append($0) })
+
+        fours.send(.one)
+        fours.send(.two)
+        fours.send(.three)
+        fours.send(.four)
+        fours.send(completion: .failure(.anError))
+
+        XCTAssertEqual(results, [.one, .two, .three, .four])
+        XCTAssertEqual(completion, .failure(.anError))
+    }
+
+    // MARK: - Predicate-related tests
+
+    private let isMultipleOf: (Int, Int) -> Bool = { seen, incoming in incoming.isMultiple(of: seen) }
+
+    func testPredicateExpectedDeduplication() {
+        var results = [Int]()
+
+        subscription = [2, 3, 3, 4].publisher
+            .removeAllDuplicates(by: isMultipleOf)
+            .sink(receiveValue: { results.append($0) })
+
+        XCTAssertEqual(results, [2, 3])
+    }
+
+    func testPredicateDeduplicationWithNoDuplicates() {
+        var results = [Int]()
+
+        subscription = [3, 5, 7, 11].publisher
+            .removeAllDuplicates(by: isMultipleOf)
+            .sink(receiveValue: { results.append($0) })
+
+        XCTAssertEqual(results, [3, 5, 7, 11])
+    }
+
+    func testPredicateDeduplicationDoesntInterfereWithFinishEvents() {
+        let integers = PassthroughSubject<Int, Never>()
+
+        var completion: Subscribers.Completion<Never>?
+        var results = [Int]()
+
+        subscription = integers
+            .removeAllDuplicates(by: isMultipleOf)
+            .sink(receiveCompletion: { completion = $0 },
+                  receiveValue: { results.append($0) })
+
+        integers.send(2)
+        integers.send(3)
+        integers.send(4)
+        integers.send(completion: .finished)
+
+        XCTAssertEqual(results, [2, 3])
+        XCTAssertEqual(completion, .finished)
+    }
+
+    func testPredicateDeduplicationDoesntInterfereWithErrorEvents() {
+        let integers = PassthroughSubject<Int, RemoveAllDuplicatesTestError>()
+
+        var completion: Subscribers.Completion<RemoveAllDuplicatesTestError>?
+        var results = [Int]()
+
+        subscription = integers
+            .removeAllDuplicates(by: isMultipleOf)
+            .sink(receiveCompletion: { completion = $0 },
+                  receiveValue: { results.append($0) })
+
+        integers.send(2)
+        integers.send(3)
+        integers.send(4)
+        integers.send(completion: .failure(.anError))
+
+        XCTAssertEqual(results, [2, 3])
+        XCTAssertEqual(completion, .failure(.anError))
+    }
+}


### PR DESCRIPTION
Tidying up and PR’ing `Publisher.removeAllDuplicates` and `.removeAllDuplicates(by:)` from an earlier sketch [on Twitter](https://twitter.com/jasdev/status/1214764966974312448) and as per your mention of [`Observable.distinct` and `.distinct(_:)`](https://github.com/RxSwiftCommunity/RxSwiftExt/blob/1e7a8683f3a8960042caa9b0ad0fc41f1217104d/Source/RxSwift/distinct.swift#L12-L69).