### PR TITLE
Add `amb()` operator

### DIFF
--- a/CombineExt.xcodeproj/project.pbxproj
+++ b/CombineExt.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		78002BB7241E915E0018AA28 /* CurrentValueRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78002BB6241E915E0018AA28 /* CurrentValueRelay.swift */; };
 		78002BB9241E91D70018AA28 /* PassthroughRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78002BB8241E91D70018AA28 /* PassthroughRelay.swift */; };
 		78002BBB241E97350018AA28 /* CurrentValueRelayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78002BBA241E97350018AA28 /* CurrentValueRelayTests.swift */; };
+		788CD8F5242F9DFB0015B3C7 /* AmbTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 788CD8F4242F9DFB0015B3C7 /* AmbTests.swift */; };
+		788CD8FB2431228C0015B3C7 /* Amb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 788CD8FA2431228C0015B3C7 /* Amb.swift */; };
 		78988A1E241EAFDD00F3A4AF /* PassthroughRelayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78988A1D241EAFDD00F3A4AF /* PassthroughRelayTests.swift */; };
 		78988A20241EB0FE00F3A4AF /* CombineExt.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "CombineExt::CombineExt::Product" /* CombineExt.framework */; };
 		78988A23241FFE2400F3A4AF /* Partition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78988A22241FFE2400F3A4AF /* Partition.swift */; };
@@ -70,6 +72,8 @@
 		78002BB6241E915E0018AA28 /* CurrentValueRelay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentValueRelay.swift; sourceTree = "<group>"; };
 		78002BB8241E91D70018AA28 /* PassthroughRelay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassthroughRelay.swift; sourceTree = "<group>"; };
 		78002BBA241E97350018AA28 /* CurrentValueRelayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentValueRelayTests.swift; sourceTree = "<group>"; };
+		788CD8F4242F9DFB0015B3C7 /* AmbTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmbTests.swift; sourceTree = "<group>"; };
+		788CD8FA2431228C0015B3C7 /* Amb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Amb.swift; sourceTree = "<group>"; };
 		78988A1D241EAFDD00F3A4AF /* PassthroughRelayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassthroughRelayTests.swift; sourceTree = "<group>"; };
 		78988A22241FFE2400F3A4AF /* Partition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Partition.swift; sourceTree = "<group>"; };
 		78988A24241FFE2E00F3A4AF /* PartitionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PartitionTests.swift; sourceTree = "<group>"; };
@@ -171,6 +175,7 @@
 				BFB4EA1424283ECF0096E9E9 /* CombineLatestManyTests.swift */,
 				DC1691112428228200B234C4 /* MapManyTests.swift */,
 				AAEAF0E82436D785007C35E0 /* SetOutputTypeTests.swift */,
+				788CD8F4242F9DFB0015B3C7 /* AmbTests.swift */,
 			);
 			path = Tests;
 			sourceTree = SOURCE_ROOT;
@@ -221,6 +226,7 @@
 				BFB4EA122428256B0096E9E9 /* CombineLatestMany.swift */,
 				DC16910E24281A1800B234C4 /* MapMany.swift */,
 				AAEAF0E62436D346007C35E0 /* SetOutputType.swift */,
+				788CD8FA2431228C0015B3C7 /* Amb.swift */,
 			);
 			path = Operators;
 			sourceTree = "<group>";
@@ -332,6 +338,7 @@
 				DC16910F24281A1800B234C4 /* MapMany.swift in Sources */,
 				78C193CF241C16C40001B7FD /* FlatMapLatest.swift in Sources */,
 				78C193DC241D0A9F0001B7FD /* Sink.swift in Sources */,
+				788CD8FB2431228C0015B3C7 /* Amb.swift in Sources */,
 				78002BB9241E91D70018AA28 /* PassthroughRelay.swift in Sources */,
 				78AA9299241B8C45009BD68B /* DemandBuffer.swift in Sources */,
 				78C193E2241D596F0001B7FD /* Dematerialize.swift in Sources */,
@@ -371,6 +378,7 @@
 				78002BBB241E97350018AA28 /* CurrentValueRelayTests.swift in Sources */,
 				78C193E4241D63620001B7FD /* DematerializeTests.swift in Sources */,
 				BF50924B241FFE8E00600DF4 /* ZipManyTests.swift in Sources */,
+				788CD8F5242F9DFB0015B3C7 /* AmbTests.swift in Sources */,
 				78988A1E241EAFDD00F3A4AF /* PassthroughRelayTests.swift in Sources */,
 				DC1691122428228200B234C4 /* MapManyTests.swift in Sources */,
 				78C193D9241CEEA80001B7FD /* CreateTests.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ All operators, utilities and helpers respect Combine's publisher contract, inclu
 * [withLatestFrom](#withLatestFrom)
 * [flatMapLatest](#flatMapLatest)
 * [assign](#assign)
+* [amb](#amb)
 * [materialize](#materialize)
 * [values](#values)
 * [failures](#failures)
@@ -136,6 +137,40 @@ var text: UITextField
 ```
 
 ------
+
+### amb
+
+Amb takes multiple publishers and mirrors the first one to emit an event. You can think of it as a race of publishers, where the first one to emit passes its events, while the others are ignored.
+
+The name `amb` comes from the [Reactive Extensions operator](http://reactivex.io/documentation/operators/amb.html), also known in RxJS as `race`.
+
+```swift
+let subject1 = PassthroughSubject<Int, Never>()
+let subject2 = PassthroughSubject<Int, Never>()
+
+subject1
+  .amb(subject2)
+  .sink(receiveCompletion: { print("amb: completed with \($0)") },
+        receiveValue: { print("amb: \($0)") })
+
+subject2.send(3) // Since this subject emit first, it becomes the active publisher
+subject1.send(1)
+subject2.send(6)
+subject1.send(8)
+subject1.send(7)
+
+subject1.send(completion: .finished)
+// Only when subject2 finishes, amb itself finishes as well, since it's the active publisher
+subject2.send(completion: .finished)
+```
+
+#### Output:
+
+```none
+amb: 3
+amb: 6
+amb: completed with .finished
+```
 
 ### materialize
 

--- a/Sources/Operators/Amb.swift
+++ b/Sources/Operators/Amb.swift
@@ -1,0 +1,155 @@
+//
+//  Amb.swift
+//  CombineExt
+//
+//  Created by Shai Mishali on 29/03/2020.
+//  Copyright © 2020 Combine Community. All rights reserved.
+//
+
+import Combine
+
+public extension Publisher {
+    /// Returns a publisher which mirrors the first publisher to emit an event
+    ///
+    /// - parameter other: The second publisher to "compete" against
+    ///
+    /// - returns: A publisher which mirrors either `self` or `other`
+    func amb<Other: Publisher>(_ other: Other)
+        -> Publishers.Amb<Self, Other> where Other.Output == Output, Other.Failure == Failure {
+        Publishers.Amb(first: self, second: other)
+    }
+
+    /// Returns a publisher which mirrors the first publisher to emit an event
+    ///
+    /// - parameter other: The second publisher to "compete" against
+    ///
+    /// - returns: A publisher which mirrors the first publisher to emit an event
+    func amb<Other: Publisher>(with others: Other...)
+        -> AnyPublisher<Self.Output, Self.Failure> where Other.Output == Output, Other.Failure == Failure {
+        let never = Empty<Output, Failure>(completeImmediately: false).eraseToAnyPublisher()
+        return others.reduce(never) { result, current in
+            result.amb(current).eraseToAnyPublisher()
+        }
+    }
+}
+
+// MARK: - Publisher
+public extension Publishers {
+    struct Amb<First: Publisher, Second: Publisher>: Publisher where First.Output == Second.Output, First.Failure == Second.Failure {
+        public func receive<S: Subscriber>(subscriber: S) where Failure == S.Failure, Output == S.Input {
+            subscriber.receive(subscription: Subscription(first: first,
+                                                          second: second,
+                                                          downstream: subscriber))
+        }
+
+        public typealias Output = First.Output
+        public typealias Failure = First.Failure
+
+        private let first: First
+        private let second: Second
+
+        public init(first: First,
+                    second: Second) {
+            self.first = first
+            self.second = second
+        }
+    }
+}
+
+// MARK: - Subscription
+private extension Publishers.Amb {
+    class Subscription<Downstream: Subscriber>: Combine.Subscription where Output == Downstream.Input, Failure == Downstream.Failure {
+        private var firstSink: Sink<First, Downstream>?
+        private var secondSink: Sink<Second, Downstream>?
+        private var preDecisionDemand = Subscribers.Demand.none
+        private var decision: Decision? {
+            didSet {
+                guard let decision = decision else { return }
+                switch decision {
+                case .first:
+                    secondSink = nil
+                case .second:
+                    firstSink = nil
+                }
+
+                request(preDecisionDemand)
+                preDecisionDemand = .none
+            }
+        }
+
+        init(first: First,
+             second: Second,
+             downstream: Downstream) {
+            self.firstSink = Sink(upstream: first,
+                                  downstream: downstream) { [weak self] in
+                                guard let self = self,
+                                      self.decision == nil else { return }
+
+                                self.decision = .first
+                             }
+
+            self.secondSink = Sink(upstream: second,
+                                   downstream: downstream) { [weak self] in
+                                guard let self = self,
+                                      self.decision == nil else { return }
+
+                                self.decision = .second
+                              }
+        }
+
+        func request(_ demand: Subscribers.Demand) {
+            guard decision != nil else {
+                preDecisionDemand += demand
+                return
+            }
+
+            firstSink?.demand(demand)
+            secondSink?.demand(demand)
+        }
+
+        func cancel() {
+            firstSink = nil
+            secondSink = nil
+        }
+    }
+}
+
+private enum Decision {
+    case first
+    case second
+}
+
+// MARK: - Sink
+private extension Publishers.Amb {
+    class Sink<Upstream: Publisher, Downstream: Subscriber>: CombineExt.Sink<Upstream, Downstream> where Upstream.Output == Downstream.Input, Upstream.Failure == Downstream.Failure {
+        private let emitted: () -> Void
+
+        init(upstream: Upstream,
+             downstream: Downstream,
+             emitted: @escaping () -> Void) {
+            self.emitted = emitted
+            super.init(upstream: upstream,
+                       downstream: downstream,
+                       transformOutput: { $0 },
+                       transformFailure: { $0 })
+        }
+
+        override func receive(subscription: Combine.Subscription) {
+            super.receive(subscription: subscription)
+
+            // We demand a single event from each upstreram publisher
+            // so we can determine who wins the race
+            subscription.request(.max(1))
+        }
+
+        override func receive(_ input: Upstream.Output) -> Subscribers.Demand {
+            emitted()
+            return buffer.buffer(value: input)
+        }
+
+        override func receive(completion: Subscribers.Completion<Downstream.Failure>) {
+            emitted()
+            buffer.complete(completion: completion)
+        }
+    }
+}

--- a/Tests/AmbTests.swift
+++ b/Tests/AmbTests.swift
@@ -1,0 +1,188 @@
+//
+//  AmbTests.swift
+//  CombineExtTests
+//
+//  Created by Shai Mishali on 29/03/2020.
+//  Copyright © 2020 Combine Community. All rights reserved.
+//
+
+import XCTest
+import Combine
+import CombineExt
+
+class AmbTests: XCTestCase {
+    var subscriptions = Set<AnyCancellable>()
+
+    override func tearDown() {
+        subscriptions = Set()
+    }
+
+    func testAmbValues() {
+        let subject1 = PassthroughSubject<Int, Never>()
+        let subject2 = PassthroughSubject<Int, Never>()
+        var completion: Subscribers.Completion<Never>?
+        var values = [Int]()
+
+        subject1
+            .amb(subject2)
+            .sink(receiveCompletion: { completion = $0 },
+                  receiveValue: { values.append($0) })
+            .store(in: &subscriptions)
+
+        subject2.send(1)
+        subject2.send(2)
+        subject1.send(6)
+        subject1.send(6)
+        subject1.send(6)
+        subject2.send(8)
+
+        XCTAssertEqual(values, [1, 2, 8])
+
+        XCTAssertNil(completion)
+        subject1.send(completion: .finished)
+        XCTAssertNil(completion)
+        subject2.send(completion: .finished)
+        XCTAssertEqual(completion, .finished)
+    }
+
+    func testAmbLimitedPreDemand() {
+        let subject1 = PassthroughSubject<Int, Never>()
+        let subject2 = PassthroughSubject<Int, Never>()
+        var values = [Int]()
+
+        let subscriber = AnySubscriber<Int, Never>(
+            receiveSubscription: { subscription in
+                subscription.request(.max(2))
+
+                subject2.send(3)
+                subject1.send(1)
+                subject1.send(0)
+                subject2.send(0)
+                subject2.send(7)
+                subject2.send(11)
+                subject1.send(12)
+                subject2.send(14)
+            },
+            receiveValue: { value in
+                values.append(value)
+                return .none
+            },
+            receiveCompletion: { _ in })
+
+        subject1
+            .amb(subject2)
+            .subscribe(subscriber)
+
+        // We expect only the first two values emitted by subject2
+        // since this is the demand that should be accumulated before
+        // a decision was made on who is the winning publisher
+        XCTAssertEqual(values, [3, 0])
+    }
+
+    func testAmbEmptyAndNever() {
+        let subject1 = Empty<Int, Never>(completeImmediately: false).append(0)
+        let subject2 = Empty<Int, Never>(completeImmediately: true).append(1)
+        var completion: Subscribers.Completion<Never>?
+        var values = [Int]()
+
+        subject1
+            .amb(subject2)
+            .sink(receiveCompletion: { completion = $0 },
+                  receiveValue: { values.append($0) })
+            .store(in: &subscriptions)
+
+        XCTAssertEqual(values, [1])
+        XCTAssertEqual(completion, .finished)
+    }
+
+    func testAmbEmptyAndEmpty() {
+        let subject1 = Empty<Int, Never>(completeImmediately: true)
+        let subject2 = Empty<Int, Never>(completeImmediately: true)
+        var completion: Subscribers.Completion<Never>?
+        var values = [Int]()
+
+        Publishers
+            .Amb(first: subject1, second: subject2)
+            .sink(receiveCompletion: { completion = $0 },
+                  receiveValue: { values.append($0) })
+            .store(in: &subscriptions)
+
+        XCTAssertEqual(completion, .finished)
+    }
+
+    func testAmbNeverAndNever() {
+        let subject1 = Empty<Int, Never>(completeImmediately: false)
+        let subject2 = Empty<Int, Never>(completeImmediately: false)
+        var completion: Subscribers.Completion<Never>?
+        var values = [Int]()
+
+        Publishers
+            .Amb(first: subject1, second: subject2)
+            .sink(receiveCompletion: { completion = $0 },
+                  receiveValue: { values.append($0) })
+            .store(in: &subscriptions)
+
+        XCTAssertNil(completion)
+    }
+
+    func testAmbVariadicValues() {
+        let subject1 = PassthroughSubject<Int, Never>()
+        let subject2 = PassthroughSubject<Int, Never>()
+        let subject3 = PassthroughSubject<Int, Never>()
+        let subject4 = PassthroughSubject<Int, Never>()
+
+        var completionPair: Subscribers.Completion<Never>?
+        var completionThree: Subscribers.Completion<Never>?
+        var completionFour: Subscribers.Completion<Never>?
+
+        var valuesPair = [Int]()
+        var valuesThree = [Int]()
+        var valuesFour = [Int]()
+
+        subject1
+            .amb(with: subject2, subject3, subject4)
+            .sink(receiveCompletion: { completionFour = $0 },
+                  receiveValue: { valuesFour.append($0) })
+            .store(in: &subscriptions)
+
+        subject1
+            .amb(with: subject2, subject3)
+            .sink(receiveCompletion: { completionThree = $0 },
+                  receiveValue: { valuesThree.append($0) })
+            .store(in: &subscriptions)
+
+        subject1
+            .amb(with: subject2)
+            .sink(receiveCompletion: { completionPair = $0 },
+                  receiveValue: { valuesPair.append($0) })
+            .store(in: &subscriptions)
+
+        subject4.send(3)
+        subject2.send(1)
+        subject2.send(2)
+        subject3.send(5)
+        subject1.send(6)
+        subject3.send(2)
+        subject1.send(6)
+        subject4.send(2)
+        subject1.send(6)
+        subject4.send(7)
+        subject2.send(8)
+
+        XCTAssertEqual(valuesFour, [3, 2, 7])
+        XCTAssertEqual(valuesThree, [1, 2, 8])
+        XCTAssertEqual(valuesPair, [1, 2, 8])
+
+        XCTAssertNil(completionFour)
+        subject1.send(completion: .finished)
+        XCTAssertNil(completionFour)
+        subject2.send(completion: .finished)
+        XCTAssertEqual(completionPair, .finished)
+        XCTAssertNil(completionFour)
+        subject3.send(completion: .finished)
+        XCTAssertEqual(completionThree, .finished)
+        XCTAssertNil(completionFour)
+        subject4.send(completion: .finished)
+        XCTAssertEqual(completionFour, .finished)
+    }
+}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,12 +1,10 @@
 ignore:
     - "Tests/**/*"
 
-status:
-    patch:
-      default:
-        threshold: 1%
-
-project:
+coverage:
+  status:
+    project:
       default:
         target: auto
         threshold: 1%
+        base: auto


### PR DESCRIPTION
The `amb` operator comes from ReactiveX (In RxSwift, RxJava etc it's called `amb`, while in `RxJS` it's called `race`). 

It takes two publishers (or a variadic number of publishers) and mirrors the emissions of the first one to emit an event.

This operator was live coded on my YouTube channel, to anyone interested in the implementation: 

[![Shai's Swift Bits Live: Creating a custom Combine operator](https://img.youtube.com/vi/Vnk4vFyuBGo/0.jpg)](https://www.youtube.com/watch?v=Vnk4vFyuBGo)