### PR TITLE
Add `tryMapMany(_:)` operator. 

### DIFF
--- a/CombineExt.xcodeproj/project.pbxproj
+++ b/CombineExt.xcodeproj/project.pbxproj
@@ -49,6 +49,8 @@
 		BFB4EA1524283ECF0096E9E9 /* CombineLatestManyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFB4EA1424283ECF0096E9E9 /* CombineLatestManyTests.swift */; };
 		DC16910F24281A1800B234C4 /* MapMany.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC16910E24281A1800B234C4 /* MapMany.swift */; };
 		DC1691122428228200B234C4 /* MapManyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1691112428228200B234C4 /* MapManyTests.swift */; };
+		DC57DC6F243CDFB10096C047 /* TryMapMany.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC57DC6E243CDFB10096C047 /* TryMapMany.swift */; };
+		DC57DC71243CE2FA0096C047 /* TryMapManyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC57DC70243CE2FA0096C047 /* TryMapManyTests.swift */; };
 		OBJ_22 /* AssignToMany.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* AssignToMany.swift */; };
 		OBJ_23 /* WithLatestFrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* WithLatestFrom.swift */; };
 		OBJ_30 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
@@ -95,6 +97,8 @@
 		"CombineExt::CombineExtTests::Product" /* CombineExtTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = CombineExtTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC16910E24281A1800B234C4 /* MapMany.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapMany.swift; sourceTree = "<group>"; };
 		DC1691112428228200B234C4 /* MapManyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapManyTests.swift; sourceTree = "<group>"; };
+		DC57DC6E243CDFB10096C047 /* TryMapMany.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TryMapMany.swift; sourceTree = "<group>"; };
+		DC57DC70243CE2FA0096C047 /* TryMapManyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TryMapManyTests.swift; sourceTree = "<group>"; };
 		OBJ_10 /* WithLatestFrom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithLatestFrom.swift; sourceTree = "<group>"; };
 		OBJ_12 /* WithLatestFromTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithLatestFromTests.swift; sourceTree = "<group>"; };
 		OBJ_16 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
@@ -170,6 +174,7 @@
 				BF50924A241FFE8E00600DF4 /* ZipManyTests.swift */,
 				BFB4EA1424283ECF0096E9E9 /* CombineLatestManyTests.swift */,
 				DC1691112428228200B234C4 /* MapManyTests.swift */,
+				DC57DC70243CE2FA0096C047 /* TryMapManyTests.swift */,
 				AAEAF0E82436D785007C35E0 /* SetOutputTypeTests.swift */,
 			);
 			path = Tests;
@@ -220,6 +225,7 @@
 				BF8121BB241FF42C006A93B8 /* ZipMany.swift */,
 				BFB4EA122428256B0096E9E9 /* CombineLatestMany.swift */,
 				DC16910E24281A1800B234C4 /* MapMany.swift */,
+				DC57DC6E243CDFB10096C047 /* TryMapMany.swift */,
 				AAEAF0E62436D346007C35E0 /* SetOutputType.swift */,
 			);
 			path = Operators;
@@ -336,6 +342,7 @@
 				78AA9299241B8C45009BD68B /* DemandBuffer.swift in Sources */,
 				78C193E2241D596F0001B7FD /* Dematerialize.swift in Sources */,
 				78002BB7241E915E0018AA28 /* CurrentValueRelay.swift in Sources */,
+				DC57DC6F243CDFB10096C047 /* TryMapMany.swift in Sources */,
 				78C193DE241D46F40001B7FD /* Materialize.swift in Sources */,
 				78988A23241FFE2400F3A4AF /* Partition.swift in Sources */,
 				BF8121BC241FF42C006A93B8 /* ZipMany.swift in Sources */,
@@ -368,6 +375,7 @@
 				78988A25241FFE2E00F3A4AF /* PartitionTests.swift in Sources */,
 				OBJ_41 /* WithLatestFromTests.swift in Sources */,
 				78C193E0241D4D8D0001B7FD /* MaterializeTests.swift in Sources */,
+				DC57DC71243CE2FA0096C047 /* TryMapManyTests.swift in Sources */,
 				78002BBB241E97350018AA28 /* CurrentValueRelayTests.swift in Sources */,
 				78C193E4241D63620001B7FD /* DematerializeTests.swift in Sources */,
 				BF50924B241FFE8E00600DF4 /* ZipManyTests.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ All operators, utilities and helpers respect Combine's publisher contract, inclu
 * [zip(with:) and Collection.zip](#ZipMany)
 * [combineLatest(with:) and Collection.combineLatest](#CombineLatestMany)
 * [mapMany(_:)](#MapMany)
+* [tryMapMany(_:)](#TryMapMany)
 * [setOutputType(to:)](#setOutputType)
 
 ### Publishers
@@ -361,6 +362,32 @@ intArrayPublisher.send([10, 2, 2, 4, 3, 8])
 
 ```none
 ["10", "2", "2", "4", "3", "8"]
+```
+
+### TryMapMany
+
+Projects each element of a publisher collection into a new publisher collection form.
+However, if  `transform`  closure throws an error, the publisher fails with the thrown error.
+
+```swift
+let intArrayPublisher = PassthroughSubject<[Int], NumberError>()
+    
+intArrayPublisher
+    .tryMapMany { number in
+        if number < 5 {
+            throw NumberError.numberSmallerThanFive
+        }
+        return "\(number)"
+    }
+    .sink(receiveValue: { print($0) })
+
+intArrayPublisher.send([10, 20, 20, 40, 30, 8])
+```
+
+#### Output:
+
+```none
+["10", "20", "20", "40", "30", "80"]
 ```
 
 ### setOutputType

--- a/Sources/Operators/TryMapMany.swift
+++ b/Sources/Operators/TryMapMany.swift
@@ -1,0 +1,55 @@
+//
+//  TryMapMany.swift
+//  CombineExt
+//
+//  Created by Joan Disho on 07/04/2020.
+//  Copyright © 2020 Combine Community. All rights reserved.
+//
+
+import Combine
+
+public extension Publisher where Output: Collection {
+    /// Projects each element of a publisher collection into a new publisher collection form.
+    ///
+    /// - parameter transform: An error-throwing transformation function which applies to each element of the source collection.
+    ///  If `transform` throws an error, the publisher fails with the thrown error.
+    ///
+    ///
+    /// - returns: A publisher collection whose elements are the result of invoking the transformation function on each element of the source.
+    ///
+    /// An example usage could look as follows:
+    ///
+    ///    ```
+    ///    let intArrayPublisher = PassthroughSubject<[Int], Never>()
+    ///
+    ///    intArrayPublisher
+    ///         .tryMapMany(String.init)
+    ///         .sink(receiveValue: { print($0) })
+    ///
+    ///    intArrayPublisher.send([10, 2, 2, 4, 3, 8])
+    ///
+    ///    // Output: ["10", "2", "2", "4", "3", "8"]
+    ///    ```
+    ///
+    /// In case of an error:
+    ///
+    ///     let intArrayPublisher = PassthroughSubject<[Int], NumberError>()
+    ///
+    ///     intArrayPublisher
+    ///         .tryMapMany { number in
+    ///             if number < 5 {
+    ///                throw NumberError.numberSmallerThanFive
+    ///             }
+    ///             return "\(number)"
+    ///         }
+    ///         .sink(receiveValue: { print($0) })
+    ///
+    ///     intArrayPublisher.send([10, 2, 2, 4, 3, 8])
+    ///
+    ///     // Output: []
+    ///     // Error: NumberError.numberSmallerThanFive
+
+    func tryMapMany<Result>(_ transform: @escaping (Output.Element) throws -> Result) -> Publishers.TryMap<Self, [Result]> {
+        tryMap { try $0.map(transform) }
+    }
+}

--- a/Tests/TryMapManyTests.swift
+++ b/Tests/TryMapManyTests.swift
@@ -1,0 +1,91 @@
+//
+//  TryMapManyTests.swift
+//  CombineExtTests
+//
+//  Created by Joan Disho on 07.04.20.
+//
+
+import XCTest
+import Combine
+
+class TryMapManyTests: XCTestCase {
+    var subscription: AnyCancellable!
+
+    func testTryMapManyWithModelAndFinishedCompletion() {
+        let source = PassthroughSubject<[Int], NumberError>()
+
+        var expectedOutput = [SomeModel]()
+
+        var completion: Subscribers.Completion<NumberError>?
+
+        subscription = source
+            .tryMapMany { number in
+                if number < 5 {
+                    throw NumberError.numberSmallerThanFive
+                }
+                return SomeModel(number)
+            }
+            .mapError { _ in NumberError.numberSmallerThanFive }
+            .sink(
+                receiveCompletion: { completion = $0 },
+                receiveValue: { $0.forEach { expectedOutput.append($0) } }
+            )
+
+        source.send([10, 20, 20, 40, 30, 8])
+        source.send(completion: .finished)
+        
+        XCTAssertEqual(
+            expectedOutput,
+            [
+                SomeModel(10),
+                SomeModel(20),
+                SomeModel(20),
+                SomeModel(40),
+                SomeModel(30),
+                SomeModel(8)
+            ]
+        )
+        XCTAssertEqual(completion, .finished)
+    }
+
+    func testTryMapManyWithModelAndFailureCompletion() {
+        let source = PassthroughSubject<[Int], NumberError>()
+
+        var expectedOutput = [SomeModel]()
+
+        var completion: Subscribers.Completion<NumberError>?
+
+        subscription = source
+            .tryMapMany { number in
+                if number < 5 {
+                    throw NumberError.numberSmallerThanFive
+                }
+                return SomeModel(number)
+            }
+            .mapError { _ in NumberError.numberSmallerThanFive }
+            .sink(
+                receiveCompletion: { completion = $0 },
+                receiveValue: { $0.forEach { expectedOutput.append($0) } }
+            )
+
+        source.send([10, 2, 2, 4, 3, 8])
+
+        XCTAssertEqual(expectedOutput, [])
+        XCTAssertEqual(completion, .failure(.numberSmallerThanFive))
+    }
+}
+
+private extension TryMapManyTests {
+    enum NumberError: Error {
+        case numberSmallerThanFive
+    }
+
+    struct SomeModel: Equatable, CustomStringConvertible {
+        let number: Int
+        var description: String { return "#\(number)" }
+
+        init(_ number: Int) {
+            self.number = number
+        }
+    }
+}


### PR DESCRIPTION
Adding the version of [`mapMany`](https://github.com/CombineCommunity/CombineExt/pull/9) with a throwable `transform` closure. 🎉

**Example:** 

```swift 
let intArrayPublisher = PassthroughSubject<[Int], NumberError>()
    
intArrayPublisher
    .tryMapMany { number in
        if number < 5 {
            throw NumberError.numberSmallerThanFive
        }
        return "\(number)"
    }
    .sink(receiveValue: { print($0) })

intArrayPublisher.send([10, 20, 20, 40, 30, 8])
```

**Output:**
```none
["10", "20", "20", "40", "30", "8"]
```
