### PR TITLE
`Set.store(_:)` `AnyCancellable`-constrained storage overloads.

### DIFF
--- a/CombineExt.xcodeproj/project.pbxproj
+++ b/CombineExt.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		78C193E0241D4D8D0001B7FD /* MaterializeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78C193DF241D4D8D0001B7FD /* MaterializeTests.swift */; };
 		78C193E2241D596F0001B7FD /* Dematerialize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78C193E1241D596F0001B7FD /* Dematerialize.swift */; };
 		78C193E4241D63620001B7FD /* DematerializeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78C193E3241D63620001B7FD /* DematerializeTests.swift */; };
+		AA2A40BB24416B7D00633241 /* Set+AnyCancellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA2A40BA24416B7D00633241 /* Set+AnyCancellable.swift */; };
+		AA2A40BD24416B9400633241 /* Set+AnyCancellableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA2A40BC24416B9400633241 /* Set+AnyCancellableTests.swift */; };
 		AAEAF0E72436D346007C35E0 /* SetOutputType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEAF0E62436D346007C35E0 /* SetOutputType.swift */; };
 		AAEAF0E92436D785007C35E0 /* SetOutputTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEAF0E82436D785007C35E0 /* SetOutputTypeTests.swift */; };
 		BF50924B241FFE8E00600DF4 /* ZipManyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF50924A241FFE8E00600DF4 /* ZipManyTests.swift */; };
@@ -91,6 +93,8 @@
 		78C193DF241D4D8D0001B7FD /* MaterializeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaterializeTests.swift; sourceTree = "<group>"; };
 		78C193E1241D596F0001B7FD /* Dematerialize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dematerialize.swift; sourceTree = "<group>"; };
 		78C193E3241D63620001B7FD /* DematerializeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DematerializeTests.swift; sourceTree = "<group>"; };
+		AA2A40BA24416B7D00633241 /* Set+AnyCancellable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Set+AnyCancellable.swift"; sourceTree = "<group>"; };
+		AA2A40BC24416B9400633241 /* Set+AnyCancellableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Set+AnyCancellableTests.swift"; sourceTree = "<group>"; };
 		AAEAF0E62436D346007C35E0 /* SetOutputType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetOutputType.swift; sourceTree = "<group>"; };
 		AAEAF0E82436D785007C35E0 /* SetOutputTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetOutputTypeTests.swift; sourceTree = "<group>"; };
 		BF50924A241FFE8E00600DF4 /* ZipManyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZipManyTests.swift; sourceTree = "<group>"; };
@@ -163,6 +167,14 @@
 			path = Common;
 			sourceTree = "<group>";
 		};
+		AA2A40B924416B6B00633241 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				AA2A40BA24416B7D00633241 /* Set+AnyCancellable.swift */,
+			);
+			path = Utilities;
+			sourceTree = "<group>";
+		};
 		OBJ_11 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
@@ -181,6 +193,7 @@
 				AAEAF0E82436D785007C35E0 /* SetOutputTypeTests.swift */,
 				788CD8F4242F9DFB0015B3C7 /* AmbTests.swift */,
 				BF84B7422426C332001BFA88 /* RemoveAllDuplicatesTests.swift */,
+				AA2A40BC24416B9400633241 /* Set+AnyCancellableTests.swift */,
 			);
 			path = Tests;
 			sourceTree = SOURCE_ROOT;
@@ -209,6 +222,7 @@
 		OBJ_7 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				AA2A40B924416B6B00633241 /* Utilities */,
 				78C193DA241D07160001B7FD /* Common */,
 				78C193D5241C2E4F0001B7FD /* Models */,
 				78002BB3241E90FE0018AA28 /* Relays */,
@@ -357,6 +371,7 @@
 				OBJ_22 /* AssignToMany.swift in Sources */,
 				AAEAF0E72436D346007C35E0 /* SetOutputType.swift in Sources */,
 				78C193D7241C2E580001B7FD /* Event.swift in Sources */,
+				AA2A40BB24416B7D00633241 /* Set+AnyCancellable.swift in Sources */,
 				OBJ_23 /* WithLatestFrom.swift in Sources */,
 				BFB4EA132428256B0096E9E9 /* CombineLatestMany.swift in Sources */,
 				78002BB5241E910C0018AA28 /* Relay.swift in Sources */,
@@ -375,6 +390,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
+				AA2A40BD24416B9400633241 /* Set+AnyCancellableTests.swift in Sources */,
 				78C193D2241C1B750001B7FD /* FlatMapLatestTests.swift in Sources */,
 				78AA9297241B8532009BD68B /* AssignToManyTests.swift in Sources */,
 				BFB4EA1524283ECF0096E9E9 /* CombineLatestManyTests.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ All operators, utilities and helpers respect Combine's publisher contract, inclu
 * [CurrentValueRelay](#CurrentValueRelay)
 * [PassthroughRelay](#PassthroughRelay)
 
+### Utilities
+* [Set.store(_:)](#SetStorage)
+
 > **Note**: This is still a relatively early version of CombineExt, with much more to be desired. I gladly accept PRs, ideas, opinions, or improvements. Thank you! :)
 
 ## Installation
@@ -516,6 +519,61 @@ only
 provide
 great
 guarantees
+```
+
+## Utilities
+
+### SetStorage
+
+Two `Element == AnyCancellable`-constrained overloads of `Set.store(_:)` are provided for easier storage of cancellables into `Set`s.
+
+The variadic version can save repeated `AnyCancellable.store(in:)` calls, e.g.
+
+```swift
+firstPublisher
+    .sink( /* … */ )
+    .store(in: &subscriptions)
+
+secondPublisher
+    .sink( /* … */ )
+    .store(in: &subscriptions)
+
+thirdPublisher
+    .sink( /* … */ )
+    .store(in: &subscriptions)
+ ```
+
+can be rewritten as
+
+```swift
+subscriptions.store(
+    firstPublisher
+        .sink( /* … */ ),
+    secondPublisher
+        .sink( /* … */ ),
+    thirdPublisher
+        .sink( /* … */ )
+)
+```
+
+and for the `Collection` variant:
+
+```swift
+let firstBatchOfCancellables = […]
+
+/* … */
+
+let secondBatchOfCancellables = […]
+
+/* … */
+
+let thirdBatchOfCancellables = […]
+
+subscriptions.store(
+    firstBatchOfCancellables +
+    secondBatchOfCancellables +
+    thirdBatchOfCancellables
+)
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -556,7 +556,7 @@ subscriptions.store(
 )
 ```
 
-and for the `Collection` variant:
+and for the `Sequence` variant:
 
 ```swift
 let firstBatchOfCancellables = […]

--- a/Sources/Utilities/Set+AnyCancellable.swift
+++ b/Sources/Utilities/Set+AnyCancellable.swift
@@ -45,7 +45,7 @@ public extension Set where Element == AnyCancellable {
         store(cancellables)
     }
 
-    /// Convenience storage method on `Set` for a `Collection` of `AnyCancellable`s.
+    /// Convenience storage method on `Set` for a `Sequence` of `AnyCancellable`s.
     ///
     /// `Set.store(_:)` can help in situations where you want to store batches of cancellables in one go, e.g.
     ///
@@ -68,7 +68,7 @@ public extension Set where Element == AnyCancellable {
     /// ```
     ///
     /// - parameter cancellables: The cancellables to store in the `Set`.
-    mutating func store<Collection: Swift.Collection>(_ cancellables: Collection) where Collection.Element == AnyCancellable {
+    mutating func store<Sequence: Swift.Sequence>(_ cancellables: Sequence) where Sequence.Element == AnyCancellable {
         cancellables.forEach { insert($0) }
     }
 }

--- a/Sources/Utilities/Set+AnyCancellable.swift
+++ b/Sources/Utilities/Set+AnyCancellable.swift
@@ -1,0 +1,74 @@
+//
+//  Set+AnyCancellable.swift
+//  CombineExt
+//
+//  Created by Jasdev Singh on 10/04/2020.
+//  Copyright © 2020 Combine Community. All rights reserved.
+//
+
+import Combine
+
+public extension Set where Element == AnyCancellable {
+    /// Convenience storage method on `Set` for a veridic number of `AnyCancellable`s.
+    ///
+    /// `Set.store(_:)` can save repeated [AnyCancellable.store(in:)](https://developer.apple.com/documentation/combine/anycancellable/3333294-store) calls, e.g.
+    ///
+    /// ```
+    /// firstPublisher
+    ///     .sink( /* … */ )
+    ///     .store(in: &subscriptions)
+    ///
+    /// secondPublisher
+    ///     .sink( /* … */ )
+    ///         .store(in: &subscriptions)
+    ///
+    /// thirdPublisher
+    ///     .sink( /* … */ )
+    ///     .store(in: &subscriptions)
+    /// ```
+    ///
+    /// can be rewritten as
+    ///
+    /// ```
+    /// subscriptions.store(
+    ///     firstPublisher
+    ///         .sink( /* … */ ),
+    ///     secondPublisher
+    ///         .sink( /* … */ ),
+    ///     thirdPublisher
+    ///         .sink( /* … */ )
+    /// )
+    /// ```
+    ///
+    /// - parameter cancellables: The cancellables to store in the `Set`.
+    mutating func store(_ cancellables: AnyCancellable...) {
+        store(cancellables)
+    }
+
+    /// Convenience storage method on `Set` for a `Collection` of `AnyCancellable`s.
+    ///
+    /// `Set.store(_:)` can help in situations where you want to store batches of cancellables in one go, e.g.
+    ///
+    /// ```
+    /// let firstBatchOfCancellables = […]
+    ///
+    /// /* … */
+    ///
+    /// let secondBatchOfCancellables = […]
+    ///
+    /// /* … */
+    ///
+    /// let thirdBatchOfCancellables = […]
+    ///
+    /// subscriptions.store(
+    ///     firstBatchOfCancellables +
+    ///     secondBatchOfCancellables +
+    ///     thirdBatchOfCancellables
+    /// )
+    /// ```
+    ///
+    /// - parameter cancellables: The cancellables to store in the `Set`.
+    mutating func store<Collection: Swift.Collection>(_ cancellables: Collection) where Collection.Element == AnyCancellable {
+        cancellables.forEach { insert($0) }
+    }
+}

--- a/Sources/Utilities/Set+AnyCancellable.swift
+++ b/Sources/Utilities/Set+AnyCancellable.swift
@@ -20,7 +20,7 @@ public extension Set where Element == AnyCancellable {
     ///
     /// secondPublisher
     ///     .sink( /* … */ )
-    ///         .store(in: &subscriptions)
+    ///     .store(in: &subscriptions)
     ///
     /// thirdPublisher
     ///     .sink( /* … */ )

--- a/Tests/Set+AnyCancellableTests.swift
+++ b/Tests/Set+AnyCancellableTests.swift
@@ -10,7 +10,7 @@ import CombineExt
 import XCTest
 
 final class SetAnyCancellableTests: XCTestCase {
-    func testStorageCollectionVariant() {
+    func testStorageSequenceVariant() {
         var subscriptions = Set<AnyCancellable>()
 
         subscriptions.store(

--- a/Tests/Set+AnyCancellableTests.swift
+++ b/Tests/Set+AnyCancellableTests.swift
@@ -1,0 +1,52 @@
+//
+//  Set+AnyCancellableTests.swift
+//  CombineExtPackageTests
+//
+//  Created by Jasdev Singh on 4/10/20.
+//
+
+import Combine
+import CombineExt
+import XCTest
+
+final class SetAnyCancellableTests: XCTestCase {
+    func testStorageCollectionVariant() {
+        var subscriptions = Set<AnyCancellable>()
+
+        subscriptions.store(
+            (1...3).map {
+                Just($0)
+                    .sink(receiveValue: { _ in })
+            }
+        )
+
+        XCTAssertEqual(subscriptions.count, 3)
+
+        subscriptions.removeAll()
+
+        XCTAssertTrue(subscriptions.isEmpty)
+
+        subscriptions.store([])
+
+        XCTAssertTrue(subscriptions.isEmpty)
+    }
+
+    func testStorageVariadicVariant() {
+        var subscriptions = Set<AnyCancellable>()
+
+        subscriptions.store(
+            Just(1)
+                .sink(receiveValue: { _ in }),
+            Just(2)
+                .sink(receiveValue: { _ in }),
+            Just(3)
+                .sink(receiveValue: { _ in })
+        )
+
+        XCTAssertEqual(subscriptions.count, 3)
+
+        subscriptions.removeAll()
+
+        XCTAssertTrue(subscriptions.isEmpty)
+    }
+}


### PR DESCRIPTION
Figured it’d be helpful to have an anlog to the [`DisposeBag.insert(_:)` variants](https://github.com/ReactiveX/RxSwift/blob/002d325b0bdee94e7882e1114af5ff4fe1e96afa/RxSwift/Disposables/DisposeBag.swift#L100-L113).