### PR TITLE
Adds ReplaySubject and Publisher.share(replay:)

### DIFF
--- a/CombineExt.xcodeproj/project.pbxproj
+++ b/CombineExt.xcodeproj/project.pbxproj
@@ -45,10 +45,14 @@
 		78C193E4241D63620001B7FD /* DematerializeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78C193E3241D63620001B7FD /* DematerializeTests.swift */; };
 		AAEAF0E72436D346007C35E0 /* SetOutputType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEAF0E62436D346007C35E0 /* SetOutputType.swift */; };
 		AAEAF0E92436D785007C35E0 /* SetOutputTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEAF0E82436D785007C35E0 /* SetOutputTypeTests.swift */; };
+		BF3C6B6C24421D27004D4A8A /* ShareReplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF3C6B6B24421D27004D4A8A /* ShareReplay.swift */; };
 		BF50924B241FFE8E00600DF4 /* ZipManyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF50924A241FFE8E00600DF4 /* ZipManyTests.swift */; };
 		BF8121BC241FF42C006A93B8 /* ZipMany.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8121BB241FF42C006A93B8 /* ZipMany.swift */; };
 		BF84B7412426B786001BFA88 /* RemoveAllDuplicates.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF84B7402426B786001BFA88 /* RemoveAllDuplicates.swift */; };
 		BF84B7432426C332001BFA88 /* RemoveAllDuplicatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF84B7422426C332001BFA88 /* RemoveAllDuplicatesTests.swift */; };
+		BF9D85D32444BB92001783E6 /* ReplaySubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9D85D22444BB92001783E6 /* ReplaySubject.swift */; };
+		BF9D85D52444D12F001783E6 /* ReplaySubjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9D85D42444D12F001783E6 /* ReplaySubjectTests.swift */; };
+		BF9D85D724450090001783E6 /* ShareReplayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9D85D624450090001783E6 /* ShareReplayTests.swift */; };
 		BFB4EA132428256B0096E9E9 /* CombineLatestMany.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFB4EA122428256B0096E9E9 /* CombineLatestMany.swift */; };
 		BFB4EA1524283ECF0096E9E9 /* CombineLatestManyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFB4EA1424283ECF0096E9E9 /* CombineLatestManyTests.swift */; };
 		DC16910F24281A1800B234C4 /* MapMany.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC16910E24281A1800B234C4 /* MapMany.swift */; };
@@ -93,10 +97,14 @@
 		78C193E3241D63620001B7FD /* DematerializeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DematerializeTests.swift; sourceTree = "<group>"; };
 		AAEAF0E62436D346007C35E0 /* SetOutputType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetOutputType.swift; sourceTree = "<group>"; };
 		AAEAF0E82436D785007C35E0 /* SetOutputTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetOutputTypeTests.swift; sourceTree = "<group>"; };
+		BF3C6B6B24421D27004D4A8A /* ShareReplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareReplay.swift; sourceTree = "<group>"; };
 		BF50924A241FFE8E00600DF4 /* ZipManyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZipManyTests.swift; sourceTree = "<group>"; };
 		BF8121BB241FF42C006A93B8 /* ZipMany.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZipMany.swift; sourceTree = "<group>"; };
 		BF84B7402426B786001BFA88 /* RemoveAllDuplicates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveAllDuplicates.swift; sourceTree = "<group>"; };
 		BF84B7422426C332001BFA88 /* RemoveAllDuplicatesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveAllDuplicatesTests.swift; sourceTree = "<group>"; };
+		BF9D85D22444BB92001783E6 /* ReplaySubject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplaySubject.swift; sourceTree = "<group>"; };
+		BF9D85D42444D12F001783E6 /* ReplaySubjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplaySubjectTests.swift; sourceTree = "<group>"; };
+		BF9D85D624450090001783E6 /* ShareReplayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareReplayTests.swift; sourceTree = "<group>"; };
 		BFB4EA122428256B0096E9E9 /* CombineLatestMany.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineLatestMany.swift; sourceTree = "<group>"; };
 		BFB4EA1424283ECF0096E9E9 /* CombineLatestManyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineLatestManyTests.swift; sourceTree = "<group>"; };
 		"CombineExt::CombineExt::Product" /* CombineExt.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = CombineExt.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -163,6 +171,14 @@
 			path = Common;
 			sourceTree = "<group>";
 		};
+		BF9D85D12444BB7F001783E6 /* Subjects */ = {
+			isa = PBXGroup;
+			children = (
+				BF9D85D22444BB92001783E6 /* ReplaySubject.swift */,
+			);
+			path = Subjects;
+			sourceTree = "<group>";
+		};
 		OBJ_11 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
@@ -181,6 +197,8 @@
 				AAEAF0E82436D785007C35E0 /* SetOutputTypeTests.swift */,
 				788CD8F4242F9DFB0015B3C7 /* AmbTests.swift */,
 				BF84B7422426C332001BFA88 /* RemoveAllDuplicatesTests.swift */,
+				BF9D85D42444D12F001783E6 /* ReplaySubjectTests.swift */,
+				BF9D85D624450090001783E6 /* ShareReplayTests.swift */,
 			);
 			path = Tests;
 			sourceTree = SOURCE_ROOT;
@@ -209,6 +227,7 @@
 		OBJ_7 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				BF9D85D12444BB7F001783E6 /* Subjects */,
 				78C193DA241D07160001B7FD /* Common */,
 				78C193D5241C2E4F0001B7FD /* Models */,
 				78002BB3241E90FE0018AA28 /* Relays */,
@@ -233,6 +252,7 @@
 				AAEAF0E62436D346007C35E0 /* SetOutputType.swift */,
 				788CD8FA2431228C0015B3C7 /* Amb.swift */,
 				BF84B7402426B786001BFA88 /* RemoveAllDuplicates.swift */,
+				BF3C6B6B24421D27004D4A8A /* ShareReplay.swift */,
 			);
 			path = Operators;
 			sourceTree = "<group>";
@@ -341,6 +361,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
+				BF3C6B6C24421D27004D4A8A /* ShareReplay.swift in Sources */,
 				DC16910F24281A1800B234C4 /* MapMany.swift in Sources */,
 				78C193CF241C16C40001B7FD /* FlatMapLatest.swift in Sources */,
 				78C193DC241D0A9F0001B7FD /* Sink.swift in Sources */,
@@ -355,6 +376,7 @@
 				BF84B7412426B786001BFA88 /* RemoveAllDuplicates.swift in Sources */,
 				78C193D4241C2DE00001B7FD /* Create.swift in Sources */,
 				OBJ_22 /* AssignToMany.swift in Sources */,
+				BF9D85D32444BB92001783E6 /* ReplaySubject.swift in Sources */,
 				AAEAF0E72436D346007C35E0 /* SetOutputType.swift in Sources */,
 				78C193D7241C2E580001B7FD /* Event.swift in Sources */,
 				OBJ_23 /* WithLatestFrom.swift in Sources */,
@@ -378,6 +400,7 @@
 				78C193D2241C1B750001B7FD /* FlatMapLatestTests.swift in Sources */,
 				78AA9297241B8532009BD68B /* AssignToManyTests.swift in Sources */,
 				BFB4EA1524283ECF0096E9E9 /* CombineLatestManyTests.swift in Sources */,
+				BF9D85D52444D12F001783E6 /* ReplaySubjectTests.swift in Sources */,
 				AAEAF0E92436D785007C35E0 /* SetOutputTypeTests.swift in Sources */,
 				78988A25241FFE2E00F3A4AF /* PartitionTests.swift in Sources */,
 				OBJ_41 /* WithLatestFromTests.swift in Sources */,
@@ -387,6 +410,7 @@
 				78C193E4241D63620001B7FD /* DematerializeTests.swift in Sources */,
 				BF50924B241FFE8E00600DF4 /* ZipManyTests.swift in Sources */,
 				788CD8F5242F9DFB0015B3C7 /* AmbTests.swift in Sources */,
+				BF9D85D724450090001783E6 /* ShareReplayTests.swift in Sources */,
 				78988A1E241EAFDD00F3A4AF /* PassthroughRelayTests.swift in Sources */,
 				DC1691122428228200B234C4 /* MapManyTests.swift in Sources */,
 				78C193D9241CEEA80001B7FD /* CreateTests.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ All operators, utilities and helpers respect Combine's publisher contract, inclu
 * [mapMany(_:)](#MapMany)
 * [setOutputType(to:)](#setOutputType)
 * [removeAllDuplicates and removeAllDuplicates(by:) ](#removeAllDuplicates)
-* [share(replay:)](#ShareReplay)
+* [share(replay:)](#share(replay:))
 
 ### Publishers
 * [AnyPublisher.create](#AnypublisherCreate)
@@ -438,7 +438,7 @@ removeAllDuplicates: 4
 
 ------
 
-### ShareReplay
+### share(replay:)
 
 Similar to [`Publisher.share`](https://developer.apple.com/documentation/combine/publisher/3204754-share), `.share(replay:)` can be used to create a publisher instance with reference semantics which replays a pre-defined amount of value events to further subscribers.
 
@@ -579,7 +579,7 @@ guarantees
 A Combine analog to Rx’s [`ReplaySubject` type](http://reactivex.io/documentation/subject.html). It’s similar to a [`CurrentValueSubject`](https://developer.apple.com/documentation/combine/currentvaluesubject) in that it buffers values, but, it takes it a step further in allowing consumers to specify the number of values to buffer and replay to future subscribers. Also, it will handle forwarding any completion events after the buffer is cleared upon subscription.
 
 ```swift
-let subject = ReplaySubject<Int, Never>(maxBufferSize: 3)
+let subject = ReplaySubject<Int, Never>(bufferSize: 3)
 
 subject.send(1)
 subject.send(2)

--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ removeAllDuplicates: 4
 
 ### ShareReplay
 
-Similar to [`Publisher.share`](https://developer.apple.com/documentation/combine/publisher/3204754-share), `.share(replay:)` can be used to create a publisher instance with reference semantics. But, it also replays value events to further subscribers.
+Similar to [`Publisher.share`](https://developer.apple.com/documentation/combine/publisher/3204754-share), `.share(replay:)` can be used to create a publisher instance with reference semantics which replays a pre-defined amount of value events to further subscribers.
 
 ```swift
 let subject = PassthroughSubject<Int, Never>()

--- a/README.md
+++ b/README.md
@@ -576,7 +576,7 @@ guarantees
 
 ### ReplaySubject
 
-A Combine analog to Rx’s [`ReplaySubject` type](http://reactivex.io/documentation/subject.html). It’s similar to a [`CurrentValueSubject`](https://developer.apple.com/documentation/combine/currentvaluesubject) in that it buffers elements, but, it takes it a step further in allowing consumers to specific the number of value events to buffer and replay to future subscribers. Also, it will handle forwarding any completion events after the buffer is cleared upon subscription.
+A Combine analog to Rx’s [`ReplaySubject` type](http://reactivex.io/documentation/subject.html). It’s similar to a [`CurrentValueSubject`](https://developer.apple.com/documentation/combine/currentvaluesubject) in that it buffers values, but, it takes it a step further in allowing consumers to specify the number of values to buffer and replay to future subscribers. Also, it will handle forwarding any completion events after the buffer is cleared upon subscription.
 
 ```swift
 let subject = ReplaySubject<Int, Never>(maxBufferSize: 3)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ All operators, utilities and helpers respect Combine's publisher contract, inclu
 * [mapMany(_:)](#MapMany)
 * [setOutputType(to:)](#setOutputType)
 * [removeAllDuplicates and removeAllDuplicates(by:) ](#removeAllDuplicates)
-* [share(replay:)](#share(replay:))
+* [share(replay:)](#sharereplay)
 
 ### Publishers
 * [AnyPublisher.create](#AnypublisherCreate)

--- a/Sources/Operators/ShareReplay.swift
+++ b/Sources/Operators/ShareReplay.swift
@@ -1,0 +1,21 @@
+//
+//  ShareReplay.swift
+//  CombineExt
+//
+//  Created by Jasdev Singh on 13/04/2020.
+//  Copyright © 2020 Combine Community. All rights reserved.
+//
+
+import Combine
+
+public extension Publisher {
+    /// An overload on [Publisher.share](https://developer.apple.com/documentation/combine/publisher/3204754-share)
+    /// that allows for buffering and replaying a `replay` amount of value events to future subscribers.
+    /// - Parameter count: The number of value events to buffer in a [first-in-first-out](https://en.wikipedia.org/wiki/FIFO_(computing_and_electronics)) manner.
+    /// - Returns: A type-erased, shared publisher that replays the specified number of value events to future subscribers.
+    func share(replay count: UInt) -> AnyPublisher<Output, Failure> {
+        multicast { ReplaySubject(maxBufferSize: count) }
+            .autoconnect()
+            .eraseToAnyPublisher()
+    }
+}

--- a/Sources/Operators/ShareReplay.swift
+++ b/Sources/Operators/ShareReplay.swift
@@ -9,9 +9,10 @@
 import Combine
 
 public extension Publisher {
-    /// An variation on [Publisher.share](https://developer.apple.com/documentation/combine/publisher/3204754-share)
+    /// A variation on [share()](https://developer.apple.com/documentation/combine/publisher/3204754-share)
     /// that allows for buffering and replaying a `replay` amount of value events to future subscribers.
-    /// - Parameter count: The number of value events to buffer in a [first-in-first-out](https://en.wikipedia.org/wiki/FIFO_(computing_and_electronics)) manner.
+    ///
+    /// - Parameter count: The number of value events to buffer in a first-in-first-out manner.
     /// - Returns: A publisher that replays the specified number of value events to future subscribers.
     func share(replay count: Int) -> Publishers.Autoconnect<Publishers.Multicast<Self, ReplaySubject<Output, Failure>>> {
         multicast { ReplaySubject(bufferSize: count) }

--- a/Sources/Operators/ShareReplay.swift
+++ b/Sources/Operators/ShareReplay.swift
@@ -9,13 +9,12 @@
 import Combine
 
 public extension Publisher {
-    /// An overload on [Publisher.share](https://developer.apple.com/documentation/combine/publisher/3204754-share)
+    /// An variation on [Publisher.share](https://developer.apple.com/documentation/combine/publisher/3204754-share)
     /// that allows for buffering and replaying a `replay` amount of value events to future subscribers.
     /// - Parameter count: The number of value events to buffer in a [first-in-first-out](https://en.wikipedia.org/wiki/FIFO_(computing_and_electronics)) manner.
-    /// - Returns: A type-erased, shared publisher that replays the specified number of value events to future subscribers.
-    func share(replay count: UInt) -> AnyPublisher<Output, Failure> {
-        multicast { ReplaySubject(maxBufferSize: count) }
+    /// - Returns: A publisher that replays the specified number of value events to future subscribers.
+    func share(replay count: Int) -> Publishers.Autoconnect<Publishers.Multicast<Self, ReplaySubject<Output, Failure>>> {
+        multicast { ReplaySubject(bufferSize: count) }
             .autoconnect()
-            .eraseToAnyPublisher()
     }
 }

--- a/Sources/Subjects/ReplaySubject.swift
+++ b/Sources/Subjects/ReplaySubject.swift
@@ -88,13 +88,10 @@ extension ReplaySubject: Publisher {
         }
 
         let subscription = Subscription(
-            downstream: AnySubscriber(subscriber)
-        ) { [weak self] in
-            guard
-                let self = self,
-                let subscriptionIndex = self.subscriptions
-                    .firstIndex(where: { $0.innerSubscriberIdentifier == subscriberIdentifier })
-                else { return }
+            downstream: AnySubscriber(subscriber)) { [weak self] in
+            guard let self = self,
+                  let subscriptionIndex = self.subscriptions
+                                              .firstIndex(where: { $0.innerSubscriberIdentifier == subscriberIdentifier }) else { return }
 
             self.subscriberIdentifiers.remove(subscriberIdentifier)
             self.subscriptions.remove(at: subscriptionIndex)

--- a/Sources/Subjects/ReplaySubject.swift
+++ b/Sources/Subjects/ReplaySubject.swift
@@ -68,8 +68,7 @@ public final class ReplaySubject<Output, Failure: Error>: Subject {
             return
         }
 
-        let subscription = Subscription(downstream:
-        AnySubscriber(subscriber)) { [weak self] in
+        let subscription = Subscription(downstream: AnySubscriber(subscriber)) { [weak self] in
             guard let self = self,
                   let subscriptionIndex = self.subscriptions
                                               .firstIndex(where: { $0.innerSubscriberIdentifier == subscriberIdentifier }) else { return }

--- a/Sources/Subjects/ReplaySubject.swift
+++ b/Sources/Subjects/ReplaySubject.swift
@@ -1,0 +1,179 @@
+//
+//  ReplaySubject.swift
+//  CombineExt
+//
+//  Created by Jasdev Singh on 13/04/2020.
+//  Copyright © 2020 Combine Community. All rights reserved.
+//
+
+import Combine
+
+/// `ReplaySubject` is a [CurrentValueSubject](https://developer.apple.com/documentation/combine/currentvaluesubject)
+/// that can buffer, well, more than one value! It stores value events, up to its `maxBufferSize` in a
+/// [first-in-first-out](https://en.wikipedia.org/wiki/FIFO_(computing_and_electronics)) manner and then replays it to
+/// future subscribers and also forwards completion events.
+///
+/// The implementation borrows heavily from [Tristan’s](https://github.com/tcldr/Entwine/blob/b839c9fcc7466878d6a823677ce608da998b95b9/Sources/Entwine/Operators/ReplaySubject.swift)
+/// with the main modifications being leaning on Shai’s [Sink](https://github.com/CombineCommunity/CombineExt/blob/7ed4677e33fdc963af404423cb563e133c271d2b/Sources/Common/Sink.swift)
+/// instead of `Entwine`’s [SinkQueue](https://github.com/tcldr/Entwine/blob/b839c9fcc7466878d6a823677ce608da998b95b9/Sources/Common/Utilities/SinkQueue.swift)
+/// and a plain ol’ `[Output]` buffer instead of a
+/// [custom, LinkedListQueue-backed one](https://github.com/tcldr/Entwine/blob/8be24a59bc91410bb29e84b1c4ae35398a5839c8/Sources/Entwine/Operators/ReplaySubject.swift#L162-L177).
+public final class ReplaySubject<Output, Failure: Error> {
+    // MARK: - Private
+
+    private let maxBufferSize: UInt
+    private var buffer = [Output]()
+
+    // MARK: - Internal
+
+    var subscriptions = [Subscription<AnySubscriber<Output, Failure>>]()
+
+    // We also track subscriber identifiers, to more quickly bottom-out double subscribes instead of having to do a
+    // linear pass over `subscriptions`.
+    var subscriberIdentifiers = Set<CombineIdentifier>()
+
+    private var completion: Subscribers.Completion<Failure>?
+    private var isActive: Bool { completion == nil }
+
+    /// The initialization point for `ReplaySubject`s.
+    /// - Parameter maxBufferSize: The maximum number of value events to buffer and replay to all future subscribers.
+    public init(maxBufferSize: UInt) {
+        self.maxBufferSize = maxBufferSize
+    }
+}
+
+// MARK: - `Subject`
+
+extension ReplaySubject: Subject {
+    public func send(_ value: Output) {
+        guard isActive else { return }
+
+        buffer.append(value)
+
+        if buffer.count > maxBufferSize {
+            buffer.removeFirst()
+        }
+
+        subscriptions.forEach { $0.forwardValueToSink(value) }
+    }
+
+    public func send(completion: Subscribers.Completion<Failure>) {
+        guard isActive else { return }
+
+        self.completion = completion
+
+        subscriptions.forEach { $0.forwardCompletionToSink(completion) }
+    }
+
+    public func send(subscription: Combine.Subscription) {
+        subscription.request(.unlimited)
+    }
+}
+
+// MARK: - `Publisher`
+
+extension ReplaySubject: Publisher {
+    public typealias Output = Output
+    public typealias Failure = Failure
+
+    public func receive<Subscriber: Combine.Subscriber>(
+        subscriber: Subscriber
+    ) where Failure == Subscriber.Failure, Output == Subscriber.Input {
+        let subscriberIdentifier = subscriber.combineIdentifier
+
+        guard !subscriberIdentifiers.contains(subscriberIdentifier) else {
+            subscriber.receive(subscription: Subscriptions.empty)
+            subscriber.receive(completion: .finished)
+            return
+        }
+
+        let subscription = Subscription(
+            downstream: AnySubscriber(subscriber)
+        ) { [weak self] in
+            guard
+                let self = self,
+                let subscriptionIndex = self.subscriptions
+                    .firstIndex(where: { $0.innerSubscriberIdentifier == subscriberIdentifier })
+            else { return }
+
+            self.subscriberIdentifiers.remove(subscriberIdentifier)
+            self.subscriptions.remove(at: subscriptionIndex)
+        }
+
+        subscriberIdentifiers.insert(subscriberIdentifier)
+        subscriptions.append(subscription)
+
+        subscriber.receive(subscription: subscription)
+        subscription.replay(buffer, completion: completion)
+    }
+}
+
+// MARK: - `ReplaySubject.Subscription`
+
+extension ReplaySubject {
+    final class Subscription<Downstream: Subscriber>
+    where Output == Downstream.Input, Failure == Downstream.Failure {
+        // MARK: - Private
+
+        private var sink: Sink<Empty<Output, Failure>, Downstream>?
+        private var cancelHandler: (() -> Void)?
+
+        // MARK: - Internal
+
+        let innerSubscriberIdentifier: CombineIdentifier
+
+        init(
+            downstream: Downstream,
+            cancelHandler: (() -> Void)?
+        ) {
+            self.sink = Sink(
+                upstream: Empty(completeImmediately: false), // `ReplaySubject`’s `Subject` conformance handles
+                // forwarding down into the `sink` instance. So, we can pretend `Sink.upstream` is an `Empty`,
+                // non-finishing publisher.
+                downstream: downstream,
+                transformOutput: { $0 },
+                transformFailure: { $0 }
+            )
+
+            self.innerSubscriberIdentifier = downstream.combineIdentifier
+            self.cancelHandler = cancelHandler
+        }
+
+        // MARK: - Internal helpers
+
+        func replay(_ buffer: [Output], completion: Subscribers.Completion<Failure>?) {
+            buffer.forEach(forwardValueToSink)
+
+            if let completion = completion {
+                forwardCompletionToSink(completion)
+            }
+        }
+
+        func forwardValueToSink(_ value: Output) {
+            _ = sink?.receive(value)
+        }
+
+        func forwardCompletionToSink(_ completion: Subscribers.Completion<Failure>) {
+            _ = sink?.receive(completion: completion)
+        }
+    }
+}
+
+// MARK: - `Combine.Subscription`
+
+extension ReplaySubject.Subscription: Subscription {
+    func request(_ demand: Subscribers.Demand) {
+        sink?.demand(demand)
+    }
+}
+
+// MARK: - `Cancellable`
+
+extension ReplaySubject.Subscription: Cancellable {
+    func cancel() {
+        cancelHandler?()
+        cancelHandler = nil
+
+        sink = nil
+    }
+}

--- a/Sources/Subjects/ReplaySubject.swift
+++ b/Sources/Subjects/ReplaySubject.swift
@@ -19,6 +19,7 @@ public final class ReplaySubject<Output, Failure: Error> {
     private var buffer = [Output]()
 
     // MARK: - Internal
+    // Keeping track of all live subscriptions, so `send` events can be forwarded to them.
     var subscriptions = [Subscription<AnySubscriber<Output, Failure>>]()
 
     // We also track subscriber identifiers, to more quickly bottom-out double subscribes instead of having to do a

--- a/Tests/ReplaySubjectTests.swift
+++ b/Tests/ReplaySubjectTests.swift
@@ -14,12 +14,12 @@ final class ReplaySubjectTests: XCTestCase {
     private var cancellable2: AnyCancellable!
     private var cancellable3: AnyCancellable!
 
-    private enum  AnError: Error, Equatable {
+    private enum AnError: Error, Equatable {
         case someError
     }
 
     func testReplaysNoValues() {
-        let subject = ReplaySubject<Int, Never>(maxBufferSize: 1)
+        let subject = ReplaySubject<Int, Never>(bufferSize: 1)
 
         var results = [Int]()
 
@@ -30,7 +30,7 @@ final class ReplaySubjectTests: XCTestCase {
     }
 
     func testMissedValueWithEmptyBuffer() {
-        let subject = ReplaySubject<Int, Never>(maxBufferSize: 0)
+        let subject = ReplaySubject<Int, Never>(bufferSize: 0)
 
         subject.send(1)
 
@@ -45,7 +45,7 @@ final class ReplaySubjectTests: XCTestCase {
     }
 
     func testMissedValueWithSingletonBuffer() {
-        let subject = ReplaySubject<Int, Never>(maxBufferSize: 1)
+        let subject = ReplaySubject<Int, Never>(bufferSize: 1)
 
         subject.send(1)
 
@@ -60,7 +60,7 @@ final class ReplaySubjectTests: XCTestCase {
     }
 
     func testMissedValuesWithManyBuffer() {
-        let subject = ReplaySubject<Int, Never>(maxBufferSize: 3)
+        let subject = ReplaySubject<Int, Never>(bufferSize: 3)
 
         subject.send(1)
         subject.send(2)
@@ -78,7 +78,7 @@ final class ReplaySubjectTests: XCTestCase {
     }
 
     func testMissedValuesWithManyBufferUnfilled() {
-        let subject = ReplaySubject<Int, Never>(maxBufferSize: 3)
+        let subject = ReplaySubject<Int, Never>(bufferSize: 3)
 
         subject.send(1)
         subject.send(2)
@@ -94,7 +94,7 @@ final class ReplaySubjectTests: XCTestCase {
     }
 
     func testMultipleSubscribers() {
-        let subject = ReplaySubject<Int, Never>(maxBufferSize: 3)
+        let subject = ReplaySubject<Int, Never>(bufferSize: 3)
 
         subject.send(1)
         subject.send(2)
@@ -126,7 +126,7 @@ final class ReplaySubjectTests: XCTestCase {
     }
 
     func testCompletionWithMultipleSubscribers() {
-        let subject = ReplaySubject<Int, Never>(maxBufferSize: 3)
+        let subject = ReplaySubject<Int, Never>(bufferSize: 3)
 
         subject.send(1)
         subject.send(2)
@@ -172,7 +172,7 @@ final class ReplaySubjectTests: XCTestCase {
     }
 
     func testErrorWithMultipleSubscribers() {
-        let subject = ReplaySubject<Int, AnError>(maxBufferSize: 3)
+        let subject = ReplaySubject<Int, AnError>(bufferSize: 3)
 
         subject.send(1)
         subject.send(2)
@@ -218,7 +218,7 @@ final class ReplaySubjectTests: XCTestCase {
     }
 
     func testValueAndCompletionPreSubscribe() {
-        let subject = ReplaySubject<Int, Never>(maxBufferSize: 1)
+        let subject = ReplaySubject<Int, Never>(bufferSize: 1)
 
         subject.send(1)
         subject.send(completion: .finished)
@@ -237,7 +237,7 @@ final class ReplaySubjectTests: XCTestCase {
     }
 
     func testNoValuesReplayedPostCompletion() {
-        let subject = ReplaySubject<Int, Never>(maxBufferSize: 1)
+        let subject = ReplaySubject<Int, Never>(bufferSize: 1)
 
         subject.send(1)
         subject.send(completion: .finished)
@@ -257,7 +257,7 @@ final class ReplaySubjectTests: XCTestCase {
     }
 
     func testNoValuesReplayedPostError() {
-        let subject = ReplaySubject<Int, AnError>(maxBufferSize: 1)
+        let subject = ReplaySubject<Int, AnError>(bufferSize: 1)
 
         subject.send(1)
         subject.send(completion: .failure(.someError))
@@ -277,7 +277,7 @@ final class ReplaySubjectTests: XCTestCase {
     }
 
     func testDoubleSubscribe() {
-        let subject = ReplaySubject<Int, Never>(maxBufferSize: 1)
+        let subject = ReplaySubject<Int, Never>(bufferSize: 1)
 
         subject.send(1)
         subject.send(completion: .finished)
@@ -297,11 +297,11 @@ final class ReplaySubjectTests: XCTestCase {
             .subscribe(sink1)
 
         XCTAssertEqual(results, [1])
-        XCTAssertEqual(completions, [.finished, .finished])
+        XCTAssertEqual(completions, [.finished])
     }
 
     func testSubscriberIdentifiers() {
-        let subject = ReplaySubject<Int, Never>(maxBufferSize: 1)
+        let subject = ReplaySubject<Int, Never>(bufferSize: 1)
 
         let subscriber = AnySubscriber<Int, Never>()
         let subscriberIdentifier = subscriber.combineIdentifier
@@ -314,7 +314,7 @@ final class ReplaySubjectTests: XCTestCase {
     }
 
     func testCancellation() {
-        let subject = ReplaySubject<Int, Never>(maxBufferSize: 1)
+        let subject = ReplaySubject<Int, Never>(bufferSize: 1)
 
         cancellable1 = subject
             .sink(receiveValue: { _ in })
@@ -326,7 +326,7 @@ final class ReplaySubjectTests: XCTestCase {
 
     private var demandSubscription: Subscription!
     func testRespectsDemand() {
-        let subject = ReplaySubject<Int, Never>(maxBufferSize: 4)
+        let subject = ReplaySubject<Int, Never>(bufferSize: 4)
 
         subject.send(1)
         subject.send(2)

--- a/Tests/ReplaySubjectTests.swift
+++ b/Tests/ReplaySubjectTests.swift
@@ -10,7 +10,7 @@ import Combine
 import XCTest
 
 final class ReplaySubjectTests: XCTestCase {
-    private var cancellables = Set<AnyCancellable>()
+    private var subscriptions = Set<AnyCancellable>()
 
     private enum AnError: Error, Equatable {
         case someError
@@ -21,10 +21,9 @@ final class ReplaySubjectTests: XCTestCase {
 
         var results = [Int]()
 
-        cancellables = Set([
-            subject
-                .sink(receiveValue: { results.append($0) })
-            ])
+        subject
+            .sink(receiveValue: { results.append($0) })
+            .store(in: &subscriptions)
 
         XCTAssertTrue(results.isEmpty)
     }
@@ -36,10 +35,9 @@ final class ReplaySubjectTests: XCTestCase {
 
         var results = [Int]()
 
-        cancellables = Set([
-            subject
-                .sink(receiveValue: { results.append($0) })
-            ])
+        subject
+            .sink(receiveValue: { results.append($0) })
+            .store(in: &subscriptions)
 
         subject.send(2)
 
@@ -53,10 +51,9 @@ final class ReplaySubjectTests: XCTestCase {
 
         var results = [Int]()
 
-        cancellables = Set([
-            subject
-                .sink(receiveValue: { results.append($0) })
-            ])
+        subject
+            .sink(receiveValue: { results.append($0) })
+            .store(in: &subscriptions)
 
         subject.send(2)
 
@@ -73,10 +70,9 @@ final class ReplaySubjectTests: XCTestCase {
 
         var results = [Int]()
 
-        cancellables = Set([
-            subject
-                .sink(receiveValue: { results.append($0) })
-            ])
+        subject
+            .sink(receiveValue: { results.append($0) })
+            .store(in: &subscriptions)
 
         subject.send(5)
 
@@ -91,10 +87,9 @@ final class ReplaySubjectTests: XCTestCase {
 
         var results = [Int]()
 
-        cancellables = Set([
-            subject
-                .sink(receiveValue: { results.append($0) })
-            ])
+        subject
+            .sink(receiveValue: { results.append($0) })
+            .store(in: &subscriptions)
 
         subject.send(3)
 
@@ -111,14 +106,17 @@ final class ReplaySubjectTests: XCTestCase {
         var results2 = [Int]()
         var results3 = [Int]()
 
-        cancellables = Set([
-            subject
-                .sink(receiveValue: { results1.append($0) }),
-            subject
-                .sink(receiveValue: { results2.append($0) }),
-            subject
-                .sink(receiveValue: { results3.append($0) })
-            ])
+        subject
+            .sink(receiveValue: { results1.append($0) })
+            .store(in: &subscriptions)
+
+        subject
+            .sink(receiveValue: { results2.append($0) })
+            .store(in: &subscriptions)
+
+        subject
+            .sink(receiveValue: { results3.append($0) })
+            .store(in: &subscriptions)
 
         subject.send(3)
 
@@ -143,23 +141,26 @@ final class ReplaySubjectTests: XCTestCase {
         var results3 = [Int]()
         var completions3 = [Subscribers.Completion<Never>]()
 
-        cancellables = Set([
-            subject
-                .sink(
-                    receiveCompletion: { completions1.append($0) },
-                    receiveValue: { results1.append($0) }
-                ),
-            subject
-                .sink(
-                    receiveCompletion: { completions2.append($0) },
-                    receiveValue: { results2.append($0) }
-                ),
-            subject
-                .sink(
-                    receiveCompletion: { completions3.append($0) },
-                    receiveValue: { results3.append($0) }
-                )
-            ])
+        subject
+            .sink(
+                receiveCompletion: { completions1.append($0) },
+                receiveValue: { results1.append($0) }
+            )
+            .store(in: &subscriptions)
+
+        subject
+            .sink(
+                receiveCompletion: { completions2.append($0) },
+                receiveValue: { results2.append($0) }
+            )
+            .store(in: &subscriptions)
+
+        subject
+            .sink(
+                receiveCompletion: { completions3.append($0) },
+                receiveValue: { results3.append($0) }
+            )
+            .store(in: &subscriptions)
 
         subject.send(3)
 
@@ -189,23 +190,27 @@ final class ReplaySubjectTests: XCTestCase {
         var results3 = [Int]()
         var completions3 = [Subscribers.Completion<AnError>]()
 
-        cancellables = Set([
-            subject
-                .sink(
-                    receiveCompletion: { completions1.append($0) },
-                    receiveValue: { results1.append($0) }
-                ),
-            subject
-                .sink(
-                    receiveCompletion: { completions2.append($0) },
-                    receiveValue: { results2.append($0) }
-                ),
-            subject
-                .sink(
-                    receiveCompletion: { completions3.append($0) },
-                    receiveValue: { results3.append($0) }
-                )
-            ])
+
+        subject
+            .sink(
+                receiveCompletion: { completions1.append($0) },
+                receiveValue: { results1.append($0) }
+            )
+            .store(in: &subscriptions)
+
+        subject
+            .sink(
+                receiveCompletion: { completions2.append($0) },
+                receiveValue: { results2.append($0) }
+            )
+            .store(in: &subscriptions)
+
+        subject
+            .sink(
+                receiveCompletion: { completions3.append($0) },
+                receiveValue: { results3.append($0) }
+            )
+            .store(in: &subscriptions)
 
         subject.send(3)
 
@@ -228,13 +233,12 @@ final class ReplaySubjectTests: XCTestCase {
         var results1 = [Int]()
         var completed = false
 
-        cancellables = Set([
-            subject
-                .sink(
-                    receiveCompletion: { _ in completed = true },
-                    receiveValue: { results1.append($0) }
-                )
-            ])
+        subject
+            .sink(
+                receiveCompletion: { _ in completed = true },
+                receiveValue: { results1.append($0) }
+            )
+            .store(in: &subscriptions)
 
         XCTAssertEqual(results1, [1])
         XCTAssertTrue(completed)
@@ -250,13 +254,12 @@ final class ReplaySubjectTests: XCTestCase {
         var results1 = [Int]()
         var completed = false
 
-        cancellables = Set([
-            subject
-                .sink(
-                    receiveCompletion: { _ in completed = true },
-                    receiveValue: { results1.append($0) }
-                )
-            ])
+        subject
+            .sink(
+                receiveCompletion: { _ in completed = true },
+                receiveValue: { results1.append($0) }
+            )
+            .store(in: &subscriptions)
 
         XCTAssertEqual(results1, [1])
         XCTAssertTrue(completed)
@@ -272,13 +275,12 @@ final class ReplaySubjectTests: XCTestCase {
         var results1 = [Int]()
         var completed = false
 
-        cancellables = Set([
-            subject
-                .sink(
-                    receiveCompletion: { _ in completed = true },
-                    receiveValue: { results1.append($0) }
-                )
-            ])
+        subject
+            .sink(
+                receiveCompletion: { _ in completed = true },
+                receiveValue: { results1.append($0) }
+            )
+            .store(in: &subscriptions)
 
         XCTAssertEqual(results1, [1])
         XCTAssertTrue(completed)

--- a/Tests/ReplaySubjectTests.swift
+++ b/Tests/ReplaySubjectTests.swift
@@ -10,9 +10,7 @@ import Combine
 import XCTest
 
 final class ReplaySubjectTests: XCTestCase {
-    private var cancellable1: AnyCancellable!
-    private var cancellable2: AnyCancellable!
-    private var cancellable3: AnyCancellable!
+    private var cancellables = Set<AnyCancellable>()
 
     private enum AnError: Error, Equatable {
         case someError
@@ -23,8 +21,10 @@ final class ReplaySubjectTests: XCTestCase {
 
         var results = [Int]()
 
-        cancellable1 = subject
-            .sink(receiveValue: { results.append($0) })
+        cancellables = Set([
+            subject
+                .sink(receiveValue: { results.append($0) })
+            ])
 
         XCTAssertTrue(results.isEmpty)
     }
@@ -36,23 +36,27 @@ final class ReplaySubjectTests: XCTestCase {
 
         var results = [Int]()
 
-        cancellable1 = subject
-            .sink(receiveValue: { results.append($0) })
+        cancellables = Set([
+            subject
+                .sink(receiveValue: { results.append($0) })
+            ])
 
         subject.send(2)
 
         XCTAssertEqual(results, [2])
     }
 
-    func testMissedValueWithSingletonBuffer() {
+    func testMissedValueWithSingleBuffer() {
         let subject = ReplaySubject<Int, Never>(bufferSize: 1)
 
         subject.send(1)
 
         var results = [Int]()
 
-        cancellable1 = subject
-            .sink(receiveValue: { results.append($0) })
+        cancellables = Set([
+            subject
+                .sink(receiveValue: { results.append($0) })
+            ])
 
         subject.send(2)
 
@@ -69,8 +73,10 @@ final class ReplaySubjectTests: XCTestCase {
 
         var results = [Int]()
 
-        cancellable1 = subject
-            .sink(receiveValue: { results.append($0) })
+        cancellables = Set([
+            subject
+                .sink(receiveValue: { results.append($0) })
+            ])
 
         subject.send(5)
 
@@ -85,8 +91,10 @@ final class ReplaySubjectTests: XCTestCase {
 
         var results = [Int]()
 
-        cancellable1 = subject
-            .sink(receiveValue: { results.append($0) })
+        cancellables = Set([
+            subject
+                .sink(receiveValue: { results.append($0) })
+            ])
 
         subject.send(3)
 
@@ -103,20 +111,14 @@ final class ReplaySubjectTests: XCTestCase {
         var results2 = [Int]()
         var results3 = [Int]()
 
-        XCTAssertEqual(subject.subscriptions.count, 0)
-        XCTAssertEqual(subject.subscriberIdentifiers.count, 0)
-
-        cancellable1 = subject
-            .sink(receiveValue: { results1.append($0) })
-
-        cancellable2 = subject
-            .sink(receiveValue: { results2.append($0) })
-
-        cancellable3 = subject
-            .sink(receiveValue: { results3.append($0) })
-
-        XCTAssertEqual(subject.subscriptions.count, 3)
-        XCTAssertEqual(subject.subscriberIdentifiers.count, 3)
+        cancellables = Set([
+            subject
+                .sink(receiveValue: { results1.append($0) }),
+            subject
+                .sink(receiveValue: { results2.append($0) }),
+            subject
+                .sink(receiveValue: { results3.append($0) })
+            ])
 
         subject.send(3)
 
@@ -141,23 +143,23 @@ final class ReplaySubjectTests: XCTestCase {
         var results3 = [Int]()
         var completions3 = [Subscribers.Completion<Never>]()
 
-        cancellable1 = subject
-            .sink(
-                receiveCompletion: { completions1.append($0) },
-                receiveValue: { results1.append($0) }
-            )
-
-        cancellable2 = subject
-            .sink(
-                receiveCompletion: { completions2.append($0) },
-                receiveValue: { results2.append($0) }
-            )
-
-        cancellable3 = subject
-            .sink(
-                receiveCompletion: { completions3.append($0) },
-                receiveValue: { results3.append($0) }
-            )
+        cancellables = Set([
+            subject
+                .sink(
+                    receiveCompletion: { completions1.append($0) },
+                    receiveValue: { results1.append($0) }
+                ),
+            subject
+                .sink(
+                    receiveCompletion: { completions2.append($0) },
+                    receiveValue: { results2.append($0) }
+                ),
+            subject
+                .sink(
+                    receiveCompletion: { completions3.append($0) },
+                    receiveValue: { results3.append($0) }
+                )
+            ])
 
         subject.send(3)
 
@@ -187,23 +189,23 @@ final class ReplaySubjectTests: XCTestCase {
         var results3 = [Int]()
         var completions3 = [Subscribers.Completion<AnError>]()
 
-        cancellable1 = subject
-            .sink(
-                receiveCompletion: { completions1.append($0) },
-                receiveValue: { results1.append($0) }
-            )
-
-        cancellable2 = subject
-            .sink(
-                receiveCompletion: { completions2.append($0) },
-                receiveValue: { results2.append($0) }
-            )
-
-        cancellable3 = subject
-            .sink(
-                receiveCompletion: { completions3.append($0) },
-                receiveValue: { results3.append($0) }
-            )
+        cancellables = Set([
+            subject
+                .sink(
+                    receiveCompletion: { completions1.append($0) },
+                    receiveValue: { results1.append($0) }
+                ),
+            subject
+                .sink(
+                    receiveCompletion: { completions2.append($0) },
+                    receiveValue: { results2.append($0) }
+                ),
+            subject
+                .sink(
+                    receiveCompletion: { completions3.append($0) },
+                    receiveValue: { results3.append($0) }
+                )
+            ])
 
         subject.send(3)
 
@@ -226,11 +228,13 @@ final class ReplaySubjectTests: XCTestCase {
         var results1 = [Int]()
         var completed = false
 
-        cancellable1 = subject
-            .sink(
-                receiveCompletion: { _ in completed = true },
-                receiveValue: { results1.append($0) }
-        )
+        cancellables = Set([
+            subject
+                .sink(
+                    receiveCompletion: { _ in completed = true },
+                    receiveValue: { results1.append($0) }
+                )
+            ])
 
         XCTAssertEqual(results1, [1])
         XCTAssertTrue(completed)
@@ -246,11 +250,13 @@ final class ReplaySubjectTests: XCTestCase {
         var results1 = [Int]()
         var completed = false
 
-        cancellable1 = subject
-            .sink(
-                receiveCompletion: { _ in completed = true },
-                receiveValue: { results1.append($0) }
-        )
+        cancellables = Set([
+            subject
+                .sink(
+                    receiveCompletion: { _ in completed = true },
+                    receiveValue: { results1.append($0) }
+                )
+            ])
 
         XCTAssertEqual(results1, [1])
         XCTAssertTrue(completed)
@@ -266,11 +272,13 @@ final class ReplaySubjectTests: XCTestCase {
         var results1 = [Int]()
         var completed = false
 
-        cancellable1 = subject
-            .sink(
-                receiveCompletion: { _ in completed = true },
-                receiveValue: { results1.append($0) }
-        )
+        cancellables = Set([
+            subject
+                .sink(
+                    receiveCompletion: { _ in completed = true },
+                    receiveValue: { results1.append($0) }
+                )
+            ])
 
         XCTAssertEqual(results1, [1])
         XCTAssertTrue(completed)
@@ -298,30 +306,6 @@ final class ReplaySubjectTests: XCTestCase {
 
         XCTAssertEqual(results, [1])
         XCTAssertEqual(completions, [.finished])
-    }
-
-    func testSubscriberIdentifiers() {
-        let subject = ReplaySubject<Int, Never>(bufferSize: 1)
-
-        let subscriber = AnySubscriber<Int, Never>()
-        let subscriberIdentifier = subscriber.combineIdentifier
-
-        subject
-            .subscribe(subscriber)
-
-        XCTAssertEqual(Array(subject.subscriberIdentifiers), [subscriberIdentifier])
-        XCTAssertEqual(subject.subscriptions.count, 1)
-    }
-
-    func testCancellation() {
-        let subject = ReplaySubject<Int, Never>(bufferSize: 1)
-
-        cancellable1 = subject
-            .sink(receiveValue: { _ in })
-
-        cancellable1.cancel()
-
-        XCTAssertTrue(subject.subscriptions.isEmpty)
     }
 
     private var demandSubscription: Subscription!

--- a/Tests/ReplaySubjectTests.swift
+++ b/Tests/ReplaySubjectTests.swift
@@ -1,0 +1,358 @@
+//
+//  ReplaySubjectTests.swift
+//  CombineExtTests
+//
+//  Created by Jasdev Singh on 4/13/20.
+//
+
+import Combine
+@testable import CombineExt
+import XCTest
+
+final class ReplaySubjectTests: XCTestCase {
+    private var cancellable1: AnyCancellable!
+    private var cancellable2: AnyCancellable!
+    private var cancellable3: AnyCancellable!
+
+    private enum  AnError: Error, Equatable {
+        case someError
+    }
+
+    func testReplaysNoValues() {
+        let subject = ReplaySubject<Int, Never>(maxBufferSize: 1)
+
+        var results = [Int]()
+
+        cancellable1 = subject
+            .sink(receiveValue: { results.append($0) })
+
+        XCTAssertTrue(results.isEmpty)
+    }
+
+    func testMissedValueWithEmptyBuffer() {
+        let subject = ReplaySubject<Int, Never>(maxBufferSize: 0)
+
+        subject.send(1)
+
+        var results = [Int]()
+
+        cancellable1 = subject
+            .sink(receiveValue: { results.append($0) })
+
+        subject.send(2)
+
+        XCTAssertEqual(results, [2])
+    }
+
+    func testMissedValueWithSingletonBuffer() {
+        let subject = ReplaySubject<Int, Never>(maxBufferSize: 1)
+
+        subject.send(1)
+
+        var results = [Int]()
+
+        cancellable1 = subject
+            .sink(receiveValue: { results.append($0) })
+
+        subject.send(2)
+
+        XCTAssertEqual(results, [1, 2])
+    }
+
+    func testMissedValuesWithManyBuffer() {
+        let subject = ReplaySubject<Int, Never>(maxBufferSize: 3)
+
+        subject.send(1)
+        subject.send(2)
+        subject.send(3)
+        subject.send(4)
+
+        var results = [Int]()
+
+        cancellable1 = subject
+            .sink(receiveValue: { results.append($0) })
+
+        subject.send(5)
+
+        XCTAssertEqual(results, [2, 3, 4, 5])
+    }
+
+    func testMissedValuesWithManyBufferUnfilled() {
+        let subject = ReplaySubject<Int, Never>(maxBufferSize: 3)
+
+        subject.send(1)
+        subject.send(2)
+
+        var results = [Int]()
+
+        cancellable1 = subject
+            .sink(receiveValue: { results.append($0) })
+
+        subject.send(3)
+
+        XCTAssertEqual(results, [1, 2, 3])
+    }
+
+    func testMultipleSubscribers() {
+        let subject = ReplaySubject<Int, Never>(maxBufferSize: 3)
+
+        subject.send(1)
+        subject.send(2)
+
+        var results1 = [Int]()
+        var results2 = [Int]()
+        var results3 = [Int]()
+
+        XCTAssertEqual(subject.subscriptions.count, 0)
+        XCTAssertEqual(subject.subscriberIdentifiers.count, 0)
+
+        cancellable1 = subject
+            .sink(receiveValue: { results1.append($0) })
+
+        cancellable2 = subject
+            .sink(receiveValue: { results2.append($0) })
+
+        cancellable3 = subject
+            .sink(receiveValue: { results3.append($0) })
+
+        XCTAssertEqual(subject.subscriptions.count, 3)
+        XCTAssertEqual(subject.subscriberIdentifiers.count, 3)
+
+        subject.send(3)
+
+        XCTAssertEqual(results1, [1, 2, 3])
+        XCTAssertEqual(results2, [1, 2, 3])
+        XCTAssertEqual(results3, [1, 2, 3])
+    }
+
+    func testCompletionWithMultipleSubscribers() {
+        let subject = ReplaySubject<Int, Never>(maxBufferSize: 3)
+
+        subject.send(1)
+        subject.send(2)
+        subject.send(completion: .finished)
+
+        var results1 = [Int]()
+        var completions1 = [Subscribers.Completion<Never>]()
+
+        var results2 = [Int]()
+        var completions2 = [Subscribers.Completion<Never>]()
+
+        var results3 = [Int]()
+        var completions3 = [Subscribers.Completion<Never>]()
+
+        cancellable1 = subject
+            .sink(
+                receiveCompletion: { completions1.append($0) },
+                receiveValue: { results1.append($0) }
+            )
+
+        cancellable2 = subject
+            .sink(
+                receiveCompletion: { completions2.append($0) },
+                receiveValue: { results2.append($0) }
+            )
+
+        cancellable3 = subject
+            .sink(
+                receiveCompletion: { completions3.append($0) },
+                receiveValue: { results3.append($0) }
+            )
+
+        subject.send(3)
+
+        XCTAssertEqual(results1, [1, 2])
+        XCTAssertEqual(completions1, [.finished])
+
+        XCTAssertEqual(results2, [1, 2])
+        XCTAssertEqual(completions2, [.finished])
+
+        XCTAssertEqual(results3, [1, 2])
+        XCTAssertEqual(completions3, [.finished])
+    }
+
+    func testErrorWithMultipleSubscribers() {
+        let subject = ReplaySubject<Int, AnError>(maxBufferSize: 3)
+
+        subject.send(1)
+        subject.send(2)
+        subject.send(completion: .failure(.someError))
+
+        var results1 = [Int]()
+        var completions1 = [Subscribers.Completion<AnError>]()
+
+        var results2 = [Int]()
+        var completions2 = [Subscribers.Completion<AnError>]()
+
+        var results3 = [Int]()
+        var completions3 = [Subscribers.Completion<AnError>]()
+
+        cancellable1 = subject
+            .sink(
+                receiveCompletion: { completions1.append($0) },
+                receiveValue: { results1.append($0) }
+            )
+
+        cancellable2 = subject
+            .sink(
+                receiveCompletion: { completions2.append($0) },
+                receiveValue: { results2.append($0) }
+            )
+
+        cancellable3 = subject
+            .sink(
+                receiveCompletion: { completions3.append($0) },
+                receiveValue: { results3.append($0) }
+            )
+
+        subject.send(3)
+
+        XCTAssertEqual(results1, [1, 2])
+        XCTAssertEqual(completions1, [.failure(.someError)])
+
+        XCTAssertEqual(results2, [1, 2])
+        XCTAssertEqual(completions2, [.failure(.someError)])
+
+        XCTAssertEqual(results3, [1, 2])
+        XCTAssertEqual(completions3, [.failure(.someError)])
+    }
+
+    func testValueAndCompletionPreSubscribe() {
+        let subject = ReplaySubject<Int, Never>(maxBufferSize: 1)
+
+        subject.send(1)
+        subject.send(completion: .finished)
+
+        var results1 = [Int]()
+        var completed = false
+
+        cancellable1 = subject
+            .sink(
+                receiveCompletion: { _ in completed = true },
+                receiveValue: { results1.append($0) }
+        )
+
+        XCTAssertEqual(results1, [1])
+        XCTAssertTrue(completed)
+    }
+
+    func testNoValuesReplayedPostCompletion() {
+        let subject = ReplaySubject<Int, Never>(maxBufferSize: 1)
+
+        subject.send(1)
+        subject.send(completion: .finished)
+        subject.send(2)
+
+        var results1 = [Int]()
+        var completed = false
+
+        cancellable1 = subject
+            .sink(
+                receiveCompletion: { _ in completed = true },
+                receiveValue: { results1.append($0) }
+        )
+
+        XCTAssertEqual(results1, [1])
+        XCTAssertTrue(completed)
+    }
+
+    func testNoValuesReplayedPostError() {
+        let subject = ReplaySubject<Int, AnError>(maxBufferSize: 1)
+
+        subject.send(1)
+        subject.send(completion: .failure(.someError))
+        subject.send(2)
+
+        var results1 = [Int]()
+        var completed = false
+
+        cancellable1 = subject
+            .sink(
+                receiveCompletion: { _ in completed = true },
+                receiveValue: { results1.append($0) }
+        )
+
+        XCTAssertEqual(results1, [1])
+        XCTAssertTrue(completed)
+    }
+
+    func testDoubleSubscribe() {
+        let subject = ReplaySubject<Int, Never>(maxBufferSize: 1)
+
+        subject.send(1)
+        subject.send(completion: .finished)
+
+        var results = [Int]()
+        var completions = [Subscribers.Completion<Never>]()
+
+        let sink1 = Subscribers.Sink<Int, Never>(
+            receiveCompletion: { completions.append($0) },
+            receiveValue: { results.append($0) }
+        )
+
+        subject
+            .subscribe(sink1)
+
+        subject
+            .subscribe(sink1)
+
+        XCTAssertEqual(results, [1])
+        XCTAssertEqual(completions, [.finished, .finished])
+    }
+
+    func testSubscriberIdentifiers() {
+        let subject = ReplaySubject<Int, Never>(maxBufferSize: 1)
+
+        let subscriber = AnySubscriber<Int, Never>()
+        let subscriberIdentifier = subscriber.combineIdentifier
+
+        subject
+            .subscribe(subscriber)
+
+        XCTAssertEqual(Array(subject.subscriberIdentifiers), [subscriberIdentifier])
+        XCTAssertEqual(subject.subscriptions.count, 1)
+    }
+
+    func testCancellation() {
+        let subject = ReplaySubject<Int, Never>(maxBufferSize: 1)
+
+        cancellable1 = subject
+            .sink(receiveValue: { _ in })
+
+        cancellable1.cancel()
+
+        XCTAssertTrue(subject.subscriptions.isEmpty)
+    }
+
+    private var demandSubscription: Subscription!
+    func testRespectsDemand() {
+        let subject = ReplaySubject<Int, Never>(maxBufferSize: 4)
+
+        subject.send(1)
+        subject.send(2)
+        subject.send(3)
+        subject.send(4)
+
+        var results = [Int]()
+        var completed = false
+
+        let subscriber = AnySubscriber<Int, Never>(
+            receiveSubscription: { subscription in
+                self.demandSubscription = subscription
+                subscription.request(.max(3))
+            },
+            receiveValue: { results.append($0); return .none },
+            receiveCompletion: { _ in completed = true }
+        )
+
+        subject
+            .subscribe(subscriber)
+
+        XCTAssertEqual(results, [1, 2, 3])
+        XCTAssertFalse(completed)
+
+        subject.send(completion: .finished)
+
+        XCTAssertTrue(completed)
+    }
+}

--- a/Tests/ShareReplayTests.swift
+++ b/Tests/ShareReplayTests.swift
@@ -1,0 +1,202 @@
+//
+//  ShareReplayTests.swift
+//  CombineExtTests
+//
+//  Created by Jasdev Singh on 4/13/20.
+//
+
+import Combine
+import CombineExt
+import XCTest
+
+final class ShareReplayTests: XCTestCase {
+    private var cancellable1: AnyCancellable!
+    private var cancellable2: AnyCancellable!
+    private var cancellable3: AnyCancellable!
+
+    private enum AnError: Error {
+        case someError
+    }
+
+    func testSharingNoReplay() {
+        var subscribeCount = 0
+
+        let publisher = Publishers.Create<Int, Never> { handler in
+            subscribeCount += 1
+            handler(.value(1))
+            handler(.value(2))
+            handler(.value(3))
+            handler(.finished)
+        }
+        .share(replay: 0)
+
+        cancellable1 = publisher
+            .sink(receiveValue: { _ in })
+
+        cancellable2 = publisher
+            .sink(receiveValue: { _ in })
+
+        cancellable3 = publisher
+            .sink(receiveValue: { _ in })
+
+        XCTAssertEqual(subscribeCount, 1)
+    }
+
+    func testSharingSingleReplay() {
+        let subject = CurrentValueSubject<Int, Never>(1)
+
+        let publisher = subject
+            .share(replay: 1)
+
+        var results = [Int]()
+
+        cancellable1 = publisher
+            .sink(receiveValue: { results.append($0) })
+
+        subject.send(2)
+
+        XCTAssertEqual(results, [1, 2])
+    }
+
+    func testSharingManyReplay() {
+        let subject = PassthroughSubject<Int, Never>()
+
+        var results1 = [Int]()
+        var results2 = [Int]()
+
+        let publisher = subject
+            .share(replay: 3)
+
+        cancellable1 = publisher
+            .sink(receiveValue: { results1.append($0) })
+
+        subject.send(1)
+        subject.send(2)
+        subject.send(3)
+        subject.send(4)
+
+        cancellable2 = publisher
+            .sink(receiveValue: { results2.append($0) })
+
+        XCTAssertEqual(results1, [1, 2, 3, 4])
+        XCTAssertEqual(results2, [2, 3, 4])
+    }
+
+    func testSharingWithFinishedEvent() {
+        let subject = PassthroughSubject<Int, Never>()
+
+        var results1 = [Int]()
+        var completions1 = [Subscribers.Completion<Never>]()
+
+        var results2 = [Int]()
+        var completions2 = [Subscribers.Completion<Never>]()
+
+        let publisher = subject
+            .share(replay: 3)
+
+        cancellable1 = publisher
+            .sink(
+                receiveCompletion: { completions1.append($0) },
+                receiveValue: { results1.append($0) }
+            )
+
+        subject.send(1)
+        subject.send(2)
+        subject.send(3)
+        subject.send(4)
+        subject.send(completion: .finished)
+
+        cancellable2 = publisher
+            .sink(
+                receiveCompletion: { completions2.append($0) },
+                receiveValue: { results2.append($0) }
+            )
+
+        XCTAssertEqual(results1, [1, 2, 3, 4])
+        XCTAssertEqual(completions1, [.finished])
+
+        XCTAssertEqual(results2, [2, 3, 4])
+        XCTAssertEqual(completions2, [.finished])
+    }
+
+    func testSharingWithErrorEvent() {
+        let subject = PassthroughSubject<Int, AnError>()
+
+        var results1 = [Int]()
+        var completions1 = [Subscribers.Completion<AnError>]()
+
+        var results2 = [Int]()
+        var completions2 = [Subscribers.Completion<AnError>]()
+
+        let publisher = subject
+            .share(replay: 3)
+
+        cancellable1 = publisher
+            .sink(
+                receiveCompletion: { completions1.append($0) },
+                receiveValue: { results1.append($0) }
+            )
+
+        subject.send(1)
+        subject.send(2)
+        subject.send(3)
+        subject.send(4)
+        subject.send(completion: .failure(.someError))
+
+        cancellable2 = publisher
+            .sink(
+                receiveCompletion: { completions2.append($0) },
+                receiveValue: { results2.append($0) }
+            )
+
+        XCTAssertEqual(results1, [1, 2, 3, 4])
+        XCTAssertEqual(completions1, [.failure(.someError)])
+
+        XCTAssertEqual(results2, [2, 3, 4])
+        XCTAssertEqual(completions2, [.failure(.someError)])
+    }
+
+    func testFinishWithNoReplay() {
+        let subject = PassthroughSubject<Int, Never>()
+
+        var results = [Int]()
+        var completions = [Subscribers.Completion<Never>]()
+
+        let publisher = subject
+            .share(replay: 1)
+
+        cancellable1 = publisher
+            .sink(
+                receiveCompletion: { completions.append($0) },
+                receiveValue: { results.append($0) }
+            )
+
+        subject.send(completion: .finished)
+        subject.send(1)
+
+        XCTAssertTrue(results.isEmpty)
+        XCTAssertEqual(completions, [.finished])
+    }
+
+    func testErrorWithNoReplay() {
+        let subject = PassthroughSubject<Int, AnError>()
+
+        var results = [Int]()
+        var completions = [Subscribers.Completion<AnError>]()
+
+        let publisher = subject
+            .share(replay: 1)
+
+        cancellable1 = publisher
+            .sink(
+                receiveCompletion: { completions.append($0) },
+                receiveValue: { results.append($0) }
+            )
+
+        subject.send(completion: .failure(.someError))
+        subject.send(1)
+
+        XCTAssertTrue(results.isEmpty)
+        XCTAssertEqual(completions, [.failure(.someError)])
+    }
+}

--- a/Tests/ShareReplayTests.swift
+++ b/Tests/ShareReplayTests.swift
@@ -21,12 +21,14 @@ final class ShareReplayTests: XCTestCase {
     func testSharingNoReplay() {
         var subscribeCount = 0
 
-        let publisher = Publishers.Create<Int, Never> { handler in
+        let publisher = Publishers.Create<Int, Never> { subscriber in
             subscribeCount += 1
-            handler(.value(1))
-            handler(.value(2))
-            handler(.value(3))
-            handler(.finished)
+            subscriber.send(1)
+            subscriber.send(2)
+            subscriber.send(3)
+            subscriber.send(completion: .finished)
+
+            return AnyCancellable { }
         }
         .share(replay: 0)
 

--- a/Tests/ShareReplayTests.swift
+++ b/Tests/ShareReplayTests.swift
@@ -10,9 +10,7 @@ import CombineExt
 import XCTest
 
 final class ShareReplayTests: XCTestCase {
-    private var cancellable1: AnyCancellable!
-    private var cancellable2: AnyCancellable!
-    private var cancellable3: AnyCancellable!
+    private var cancellables = Set<AnyCancellable>()
 
     private enum AnError: Error {
         case someError
@@ -32,14 +30,14 @@ final class ShareReplayTests: XCTestCase {
         }
         .share(replay: 0)
 
-        cancellable1 = publisher
-            .sink(receiveValue: { _ in })
-
-        cancellable2 = publisher
-            .sink(receiveValue: { _ in })
-
-        cancellable3 = publisher
-            .sink(receiveValue: { _ in })
+        cancellables = Set([
+            publisher
+                .sink(receiveValue: { _ in }),
+            publisher
+                .sink(receiveValue: { _ in }),
+            publisher
+                .sink(receiveValue: { _ in })
+            ])
 
         XCTAssertEqual(subscribeCount, 1)
     }
@@ -52,8 +50,10 @@ final class ShareReplayTests: XCTestCase {
 
         var results = [Int]()
 
-        cancellable1 = publisher
-            .sink(receiveValue: { results.append($0) })
+        cancellables = Set([
+            publisher
+                .sink(receiveValue: { results.append($0) })
+            ])
 
         subject.send(2)
 
@@ -69,16 +69,20 @@ final class ShareReplayTests: XCTestCase {
         let publisher = subject
             .share(replay: 3)
 
-        cancellable1 = publisher
-            .sink(receiveValue: { results1.append($0) })
+        cancellables = Set([
+            publisher
+                .sink(receiveValue: { results1.append($0) })
+            ])
 
         subject.send(1)
         subject.send(2)
         subject.send(3)
         subject.send(4)
 
-        cancellable2 = publisher
-            .sink(receiveValue: { results2.append($0) })
+        cancellables.insert(
+            publisher
+                .sink(receiveValue: { results2.append($0) })
+            )
 
         XCTAssertEqual(results1, [1, 2, 3, 4])
         XCTAssertEqual(results2, [2, 3, 4])
@@ -96,11 +100,13 @@ final class ShareReplayTests: XCTestCase {
         let publisher = subject
             .share(replay: 3)
 
-        cancellable1 = publisher
-            .sink(
-                receiveCompletion: { completions1.append($0) },
-                receiveValue: { results1.append($0) }
-            )
+        cancellables = Set([
+            publisher
+                .sink(
+                    receiveCompletion: { completions1.append($0) },
+                    receiveValue: { results1.append($0) }
+                )
+            ])
 
         subject.send(1)
         subject.send(2)
@@ -108,10 +114,12 @@ final class ShareReplayTests: XCTestCase {
         subject.send(4)
         subject.send(completion: .finished)
 
-        cancellable2 = publisher
-            .sink(
-                receiveCompletion: { completions2.append($0) },
-                receiveValue: { results2.append($0) }
+        cancellables.insert(
+            publisher
+                .sink(
+                    receiveCompletion: { completions2.append($0) },
+                    receiveValue: { results2.append($0) }
+                )
             )
 
         XCTAssertEqual(results1, [1, 2, 3, 4])
@@ -133,11 +141,13 @@ final class ShareReplayTests: XCTestCase {
         let publisher = subject
             .share(replay: 3)
 
-        cancellable1 = publisher
-            .sink(
-                receiveCompletion: { completions1.append($0) },
-                receiveValue: { results1.append($0) }
-            )
+        cancellables = Set([
+            publisher
+                .sink(
+                    receiveCompletion: { completions1.append($0) },
+                    receiveValue: { results1.append($0) }
+                )
+            ])
 
         subject.send(1)
         subject.send(2)
@@ -145,10 +155,12 @@ final class ShareReplayTests: XCTestCase {
         subject.send(4)
         subject.send(completion: .failure(.someError))
 
-        cancellable2 = publisher
-            .sink(
-                receiveCompletion: { completions2.append($0) },
-                receiveValue: { results2.append($0) }
+        cancellables.insert(
+            publisher
+                .sink(
+                    receiveCompletion: { completions2.append($0) },
+                    receiveValue: { results2.append($0) }
+                )
             )
 
         XCTAssertEqual(results1, [1, 2, 3, 4])
@@ -167,11 +179,13 @@ final class ShareReplayTests: XCTestCase {
         let publisher = subject
             .share(replay: 1)
 
-        cancellable1 = publisher
-            .sink(
-                receiveCompletion: { completions.append($0) },
-                receiveValue: { results.append($0) }
-            )
+        cancellables = Set([
+            publisher
+                .sink(
+                    receiveCompletion: { completions.append($0) },
+                    receiveValue: { results.append($0) }
+                )
+            ])
 
         subject.send(completion: .finished)
         subject.send(1)
@@ -189,11 +203,13 @@ final class ShareReplayTests: XCTestCase {
         let publisher = subject
             .share(replay: 1)
 
-        cancellable1 = publisher
-            .sink(
-                receiveCompletion: { completions.append($0) },
-                receiveValue: { results.append($0) }
-            )
+        cancellables = Set([
+            publisher
+                .sink(
+                    receiveCompletion: { completions.append($0) },
+                    receiveValue: { results.append($0) }
+                )
+            ])
 
         subject.send(completion: .failure(.someError))
         subject.send(1)


### PR DESCRIPTION
h/t to @tcldr for the reference implementation I leaned on and adapted to Shai’s `DemandBuffer` type. 💯 