### PR TITLE
Fix double-subscribe bug in ReplaySubject.

### DIFF
--- a/Tests/ReplaySubjectTests.swift
+++ b/Tests/ReplaySubjectTests.swift
@@ -325,22 +325,24 @@ final class ReplaySubjectTests: XCTestCase {
         subject.send(2)
         subject.send(completion: .finished)
 
-        var results = [Int]()
+        var results = [String]()
         var completions = [Subscribers.Completion<Never>]()
 
-        let subscriber = AnySubscriber<Int, Never>(
+        let subscriber = AnySubscriber<String, Never>(
             receiveSubscription: { $0.request(.max(1)) },
             receiveValue: { results.append($0); return .none },
             receiveCompletion: { completions.append($0) }
         )
 
         subject
+            .map { "a\($0)" }
             .subscribe(subscriber)
 
         subject
+            .map { "b\($0)" }
             .subscribe(subscriber)
 
-        XCTAssertEqual([2, 2], results)
+        XCTAssertEqual(["a2", "b2"], results)
         XCTAssertEqual([.finished, .finished], completions)
     }
 }


### PR DESCRIPTION
👋🏽

I found a small inconsistency with how `ReplaySubject` handles double subscribes compared to `CurrentValue-` and `PassthroughSubject` (cc’ing @tcldr, so this is also on Entwine’s radar).

It turns out my initial assumption that double subscribes were ignored wasn’t actually inherent to `Subject`s and is instead a nuance of `Sink`. The folks behind OpenCombine [noticed this](https://github.com/broadwaylamb/OpenCombine/blob/d680f09932fe68942c3d391d6df296d38b9dcd05/Sources/OpenCombine/Subscribers/Subscribers.Sink.swift#L27), too. `Sink`s keep an internal subscription state that prevents subscriptions from doubly coming through.

I dig into this in greater detail [here](https://jasdev.me/publisher-temperature-primer).

We can verify that `Sink` keeps state by instead double subscribing to a `PassthroughSubject` with a more barebones `AnySubscriber` and seeing events logged twice.

```swift
import Combine

let subject = PassthroughSubject<Int, Never>()

let subscriber = AnySubscriber<Int, Never>(
	receiveSubscription: { $0.request(.unlimited) },
	receiveValue: { print($0); return .none },
	receiveCompletion: { print($0) }
)

subject
	.subscribe(subscriber)

subject
	.subscribe(subscriber)

subject.send(1)
subject.send(2)
subject.send(completion: .finished)
```

Logs:

```none
1
1
2
2
finished
finished
```

This PR updates `ReplaySubject` to follow suit and adjusts the related test, accordingly.