### PR TITLE
Added `assign(to: on: ownership:)` operator

### DIFF
--- a/CombineExt.xcodeproj/project.pbxproj
+++ b/CombineExt.xcodeproj/project.pbxproj
@@ -21,6 +21,9 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		712E87BD2465DEDE00431F5C /* ObjectOwnership.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712E87BC2465DEDE00431F5C /* ObjectOwnership.swift */; };
+		71E6F4EC24655F3A00FB4103 /* AssignOwnership.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71E6F4EB24655F3A00FB4103 /* AssignOwnership.swift */; };
+		71E6F4EE2465616100FB4103 /* AssignOwnershipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71E6F4ED2465616100FB4103 /* AssignOwnershipTests.swift */; };
 		78002BB5241E910C0018AA28 /* Relay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78002BB4241E910C0018AA28 /* Relay.swift */; };
 		78002BB7241E915E0018AA28 /* CurrentValueRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78002BB6241E915E0018AA28 /* CurrentValueRelay.swift */; };
 		78002BB9241E91D70018AA28 /* PassthroughRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78002BB8241E91D70018AA28 /* PassthroughRelay.swift */; };
@@ -76,6 +79,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		712E87BC2465DEDE00431F5C /* ObjectOwnership.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectOwnership.swift; sourceTree = "<group>"; };
+		71E6F4EB24655F3A00FB4103 /* AssignOwnership.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignOwnership.swift; sourceTree = "<group>"; };
+		71E6F4ED2465616100FB4103 /* AssignOwnershipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignOwnershipTests.swift; sourceTree = "<group>"; };
 		78002BB4241E910C0018AA28 /* Relay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Relay.swift; sourceTree = "<group>"; };
 		78002BB6241E915E0018AA28 /* CurrentValueRelay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentValueRelay.swift; sourceTree = "<group>"; };
 		78002BB8241E91D70018AA28 /* PassthroughRelay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassthroughRelay.swift; sourceTree = "<group>"; };
@@ -162,6 +168,7 @@
 			isa = PBXGroup;
 			children = (
 				78C193D6241C2E580001B7FD /* Event.swift */,
+				712E87BC2465DEDE00431F5C /* ObjectOwnership.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -188,6 +195,7 @@
 			children = (
 				OBJ_12 /* WithLatestFromTests.swift */,
 				78AA9296241B8532009BD68B /* AssignToManyTests.swift */,
+				71E6F4ED2465616100FB4103 /* AssignOwnershipTests.swift */,
 				78C193D0241C1B450001B7FD /* FlatMapLatestTests.swift */,
 				78C193D8241CEEA80001B7FD /* CreateTests.swift */,
 				78C193DF241D4D8D0001B7FD /* MaterializeTests.swift */,
@@ -245,6 +253,7 @@
 			isa = PBXGroup;
 			children = (
 				OBJ_9 /* AssignToMany.swift */,
+				71E6F4EB24655F3A00FB4103 /* AssignOwnership.swift */,
 				OBJ_10 /* WithLatestFrom.swift */,
 				78C193CE241C16C40001B7FD /* FlatMapLatest.swift */,
 				78C193D3241C2DE00001B7FD /* Create.swift */,
@@ -380,11 +389,13 @@
 				78988A23241FFE2400F3A4AF /* Partition.swift in Sources */,
 				BF8121BC241FF42C006A93B8 /* ZipMany.swift in Sources */,
 				BF84B7412426B786001BFA88 /* RemoveAllDuplicates.swift in Sources */,
+				71E6F4EC24655F3A00FB4103 /* AssignOwnership.swift in Sources */,
 				78C193D4241C2DE00001B7FD /* Create.swift in Sources */,
 				OBJ_22 /* AssignToMany.swift in Sources */,
 				BF8EDF4C2453529000B0CC75 /* PrefixDuration.swift in Sources */,
 				BF9D85D32444BB92001783E6 /* ReplaySubject.swift in Sources */,
 				AAEAF0E72436D346007C35E0 /* SetOutputType.swift in Sources */,
+				712E87BD2465DEDE00431F5C /* ObjectOwnership.swift in Sources */,
 				78C193D7241C2E580001B7FD /* Event.swift in Sources */,
 				OBJ_23 /* WithLatestFrom.swift in Sources */,
 				BFB4EA132428256B0096E9E9 /* CombineLatestMany.swift in Sources */,
@@ -407,6 +418,7 @@
 				78C193D2241C1B750001B7FD /* FlatMapLatestTests.swift in Sources */,
 				78AA9297241B8532009BD68B /* AssignToManyTests.swift in Sources */,
 				BFB4EA1524283ECF0096E9E9 /* CombineLatestManyTests.swift in Sources */,
+				71E6F4EE2465616100FB4103 /* AssignOwnershipTests.swift in Sources */,
 				BF9D85D52444D12F001783E6 /* ReplaySubjectTests.swift in Sources */,
 				AAEAF0E92436D785007C35E0 /* SetOutputTypeTests.swift in Sources */,
 				78988A25241FFE2E00F3A4AF /* PartitionTests.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -143,6 +143,20 @@ var text: UITextField
             and: \.text, on: text)
 ```
 
+CombineExt provides an additional overload — `assign(to:on​:ownership)` — which lets you specify the kind of ownersip you want for your assign operation: `strong`, `weak` or `unowned`.
+
+```swift
+// Retain `self` strongly
+subscription = subject.assign(to: \.value, on: self)
+subscription = subject.assign(to: \.value, on: self, ownership: .strong)
+
+// Use a `weak` reference to `self`
+subscription = subject.assign(to: \.value, on: self, ownership: .weak)
+
+// Use an `unowned` reference to `self`
+subscription = subject.assign(to: \.value, on: self, ownership: .unowned)
+```
+
 ------
 
 ### amb

--- a/Sources/Models/ObjectOwnership.swift
+++ b/Sources/Models/ObjectOwnership.swift
@@ -1,0 +1,26 @@
+//
+//  ObjectOwnership.swift
+//  CombineExt
+//
+//  Created by Dmitry Kuznetsov on 08/05/2020.
+//  Copyright © 2020 Combine Community. All rights reserved.
+//
+
+import Foundation
+
+/// The ownership of an object
+///
+/// - seealso: https://docs.swift.org/swift-book/LanguageGuide/AutomaticReferenceCounting.html#ID52
+public enum ObjectOwnership {
+    /// Keep a strong hold of the object, preventing ARC
+    /// from disposing it until its released or has no references.
+    case strong
+
+    /// Weakly owned. Does not keep a strong hold of the object,
+    /// allowing ARC to dispose it even if its referenced.
+    case weak
+
+    /// Unowned. Similar to weak, but implicitly unwrapped so may
+    /// crash if the object is released beore being accessed.
+    case unowned
+}

--- a/Sources/Operators/AssignOwnership.swift
+++ b/Sources/Operators/AssignOwnership.swift
@@ -1,0 +1,113 @@
+//
+//  AssignOwnership.swift
+//  CombineExt
+//
+//  Created by Dmitry Kuznetsov on 08/05/2020.
+//  Copyright © 2020 Combine Community. All rights reserved.
+//
+
+#if canImport(Combine)
+import Combine
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+public extension Publisher where Self.Failure == Never {
+    /// Assigns a publisher’s output to a property of an object.
+    ///
+    /// - parameter keyPath: A key path that indicates the property to assign.
+    /// - parameter object: The object that contains the property.
+    ///                     The subscriber assigns the object’s property every time
+    ///                     it receives a new value.
+    /// - parameter ownership: The retainment / ownership strategy for the object, defaults to `strong`.
+    ///
+    /// - returns: An AnyCancellable instance. Call cancel() on this instance when you no longer want
+    ///            the publisher to automatically assign the property. Deinitializing this instance
+    ///            will also cancel automatic assignment.
+    func assign<Root: AnyObject>(to keyPath: ReferenceWritableKeyPath<Root, Self.Output>,
+                                 on object: Root,
+                                 ownership: ObjectOwnership = .strong) -> AnyCancellable {
+        switch ownership {
+        case .strong:
+            return assign(to: keyPath, on: object)
+        case .weak:
+            return sink { [weak object] value in
+                object?[keyPath: keyPath] = value
+            }
+        case .unowned:
+            return sink { [unowned object] value in
+                object[keyPath: keyPath] = value
+            }
+        }
+    }
+
+    /// Assigns each element from a Publisher to properties of the provided objects
+    ///
+    /// - Parameters:
+    ///   - keyPath1: The key path of the first property to assign.
+    ///   - object1: The first object on which to assign the value.
+    ///   - keyPath2: The key path of the second property to assign.
+    ///   - object2: The second object on which to assign the value.
+    ///   - ownership: The retainment / ownership strategy for the object, defaults to `strong`.
+    ///
+    /// - Returns: A cancellable instance; used when you end assignment of the received value.
+    ///            Deallocation of the result will tear down the subscription stream.
+    func assign<Root1: AnyObject, Root2: AnyObject>(
+        to keyPath1: ReferenceWritableKeyPath<Root1, Output>, on object1: Root1,
+        and keyPath2: ReferenceWritableKeyPath<Root2, Output>, on object2: Root2,
+        ownership: ObjectOwnership = .strong
+    ) -> AnyCancellable {
+        switch ownership {
+        case .strong:
+            return assign(to: keyPath1, on: object1, and: keyPath2, on: object2)
+        case .weak:
+            return sink { [weak object1, weak object2] value in
+                object1?[keyPath: keyPath1] = value
+                object2?[keyPath: keyPath2] = value
+            }
+        case .unowned:
+            return sink { [unowned object1, unowned object2] value in
+                object1[keyPath: keyPath1] = value
+                object2[keyPath: keyPath2] = value
+            }
+        }
+    }
+
+    /// Assigns each element from a Publisher to properties of the provided objects
+    ///
+    /// - Parameters:
+    ///   - keyPath1: The key path of the first property to assign.
+    ///   - object1: The first object on which to assign the value.
+    ///   - keyPath2: The key path of the second property to assign.
+    ///   - object2: The second object on which to assign the value.
+    ///   - keyPath3: The key path of the third property to assign.
+    ///   - object3: The third object on which to assign the value.
+    ///   - ownership: The retainment / ownership strategy for the object, defaults to `strong`.
+    ///
+    /// - Returns: A cancellable instance; used when you end assignment of the received value.
+    ///            Deallocation of the result will tear down the subscription stream.
+    func assign<Root1: AnyObject, Root2: AnyObject, Root3: AnyObject>(
+        to keyPath1: ReferenceWritableKeyPath<Root1, Output>, on object1: Root1,
+        and keyPath2: ReferenceWritableKeyPath<Root2, Output>, on object2: Root2,
+        and keyPath3: ReferenceWritableKeyPath<Root3, Output>, on object3: Root3,
+        ownership: ObjectOwnership = .strong
+    ) -> AnyCancellable {
+        switch ownership {
+        case .strong:
+            return assign(to: keyPath1, on: object1,
+                          and: keyPath2, on: object2,
+                          and: keyPath3, on: object3)
+        case .weak:
+            return sink { [weak object1, weak object2, weak object3] value in
+                object1?[keyPath: keyPath1] = value
+                object2?[keyPath: keyPath2] = value
+                object3?[keyPath: keyPath3] = value
+            }
+        case .unowned:
+            return sink { [unowned object1, unowned object2, unowned object3] value in
+                object1[keyPath: keyPath1] = value
+                object2[keyPath: keyPath2] = value
+                object3[keyPath: keyPath3] = value
+            }
+        }
+    }
+}
+#endif

--- a/Sources/Operators/AssignToMany.swift
+++ b/Sources/Operators/AssignToMany.swift
@@ -11,7 +11,7 @@ import Combine
 
 @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public extension Publisher where Self.Failure == Never {
-    /// Assigns each element from a Publisher to properties of the provided object
+    /// Assigns each element from a Publisher to properties of the provided objects
     ///
     /// - Parameters:
     ///   - keyPath1: The key path of the first property to assign.
@@ -28,7 +28,7 @@ public extension Publisher where Self.Failure == Never {
         })
     }
 
-    /// Assigns each element from a Publisher to properties of the provided object
+    /// Assigns each element from a Publisher to properties of the provided objects
     ///
     /// - Parameters:
     ///   - keyPath1: The key path of the first property to assign.

--- a/Tests/AssignOwnershipTests.swift
+++ b/Tests/AssignOwnershipTests.swift
@@ -1,0 +1,86 @@
+//
+//  AssignOwnershipTests.swift
+//  CombineExt
+//
+//  Created by Dmitry Kuznetsov on 08/05/2020.
+//  Copyright © 2020 Combine Community. All rights reserved.
+//
+
+import XCTest
+import Combine
+import CombineExt
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+class AssignOwnershipTests: XCTestCase {
+    var subscription: AnyCancellable!
+    var value = 0
+    var subject: PassthroughSubject<Int, Never>!
+
+    override func setUp() {
+        super.setUp()
+
+        subscription = nil
+        subject = PassthroughSubject<Int, Never>()
+        value = 0
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        subject = nil
+    }
+
+    func testWeakAssign() {
+        checkSingleAssign(for: .weak)
+    }
+
+    func testStrongAssign() {
+        checkSingleAssign(for: .strong)
+    }
+
+    func testUnownedAssign() {
+        checkSingleAssign(for: .unowned)
+    }
+
+    func testWeakRetain() {
+        checkRetainValue(for: .weak) { initialRetainCount, resultRetainCount in
+            XCTAssertEqual(initialRetainCount, resultRetainCount)
+        }
+    }
+
+    func testStrongRetain() {
+        checkRetainValue(for: .strong) { initialRetainCount, resultRetainCount in
+            XCTAssertEqual(initialRetainCount + 1, resultRetainCount)
+        }
+    }
+
+    func testUnownedRetain() {
+        checkRetainValue(for: .unowned) { initialRetainCount, resultRetainCount in
+            XCTAssertEqual(initialRetainCount, resultRetainCount)
+        }
+    }
+
+    private func checkSingleAssign(for ownership: ObjectOwnership) {
+        subscription = subject
+            .assign(to: \.value, on: self, ownership: ownership)
+
+        let newValue1 = 10
+        subject.send(newValue1)
+        XCTAssertEqual(value, newValue1)
+
+        let newValue2 = 11
+        subject.send(newValue2)
+        XCTAssertEqual(value, newValue2)
+    }
+
+    private func checkRetainValue(for ownership: ObjectOwnership, completion: (Int, Int) -> Void) {
+        let initialRetainCount = CFGetRetainCount(self)
+
+        subscription = subject
+            .assign(to: \.value, on: self, ownership: ownership)
+
+        let resultRetainCount = CFGetRetainCount(self)
+
+        completion(initialRetainCount, resultRetainCount)
+    }
+}

--- a/Tests/AssignToManyTests.swift
+++ b/Tests/AssignToManyTests.swift
@@ -13,9 +13,29 @@ import CombineExt
 
 @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 class AssignToManyTests: XCTestCase {
-    private typealias RetainCheckCompletion = ([(initialRetainCount: Int, resultRetainCount: Int)]) -> Void
-
     var subscription: AnyCancellable!
+
+    func testAssignToOne() {
+        let source = PassthroughSubject<Int, Never>()
+
+        for ownership in [ObjectOwnership.strong, .weak, .unowned] {
+            let dest1 = Fake1(prop: 0)
+
+            XCTAssertEqual(dest1.prop, 0)
+
+            subscription = source
+                .assign(to: \.prop, on: dest1, ownership: ownership)
+
+            source.send(4)
+            XCTAssertEqual(dest1.prop, 4, "\(ownership) ownership")
+
+            source.send(12)
+            XCTAssertEqual(dest1.prop, 12, "\(ownership) ownership")
+
+            source.send(-7)
+            XCTAssertEqual(dest1.prop, -7, "\(ownership) ownership")
+        }
+    }
 
     func testAssignToTwo() {
         let source = PassthroughSubject<Int, Never>()
@@ -74,77 +94,6 @@ class AssignToManyTests: XCTestCase {
             XCTAssertEqual(dest2.ivar, "Meh", "\(ownership) ownership")
             XCTAssertEqual(dest3.value, "MehMehMeh", "\(ownership) ownership")
         }
-    }
-
-    func testWeakOwnership() {
-        let completion: RetainCheckCompletion = {
-            $0.forEach {
-                XCTAssertEqual($0.initialRetainCount, $0.resultRetainCount)
-            }
-        }
-        checkAssign2RetainValue(for: .weak, completion: completion)
-        checkAssign3RetainValue(for: .weak, completion: completion)
-    }
-
-    func testUnownedOwnership() {
-        let completion: RetainCheckCompletion = {
-            $0.forEach {
-                XCTAssertEqual($0.initialRetainCount, $0.resultRetainCount)
-            }
-        }
-        checkAssign2RetainValue(for: .unowned, completion: completion)
-        checkAssign3RetainValue(for: .unowned, completion: completion)
-    }
-
-    func testStrongOwnership() {
-        let completion: RetainCheckCompletion = {
-            $0.forEach {
-                XCTAssertEqual($0.initialRetainCount + 1, $0.resultRetainCount)
-            }
-        }
-        checkAssign2RetainValue(for: .strong, completion: completion)
-        checkAssign3RetainValue(for: .strong, completion: completion)
-    }
-
-    private func checkAssign2RetainValue(for ownership: ObjectOwnership, completion: RetainCheckCompletion) {
-        let source = PassthroughSubject<Int, Never>()
-        let dest1 = Fake1(prop: 0)
-        let dest2 = Fake2(ivar: 0)
-        let initialRetainCount1 = CFGetRetainCount(dest1)
-        let initialRetainCount2 = CFGetRetainCount(dest2)
-
-        subscription = source
-            .assign(to: \.prop, on: dest1, and: \.ivar, on: dest2, ownership: ownership)
-
-        let resultRetainCount1 = CFGetRetainCount(dest1)
-        let resultRetainCount2 = CFGetRetainCount(dest2)
-
-        completion([(initialRetainCount1, resultRetainCount1),
-                    (initialRetainCount2, resultRetainCount2)])
-    }
-
-    private func checkAssign3RetainValue(for ownership: ObjectOwnership, completion: RetainCheckCompletion) {
-        let source = PassthroughSubject<String, Never>()
-        let dest1 = Fake1(prop: "")
-        let dest2 = Fake2(ivar: "")
-        let dest3 = Fake3(value: "") { String(repeating: $0, count: $0.count) }
-        let initialRetainCount1 = CFGetRetainCount(dest1)
-        let initialRetainCount2 = CFGetRetainCount(dest2)
-        let initialRetainCount3 = CFGetRetainCount(dest3)
-
-        subscription = source
-            .assign(to: \.prop, on: dest1,
-                    and: \.ivar, on: dest2,
-                    and: \.value, on: dest3,
-                    ownership: ownership)
-
-        let resultRetainCount1 = CFGetRetainCount(dest1)
-        let resultRetainCount2 = CFGetRetainCount(dest2)
-        let resultRetainCount3 = CFGetRetainCount(dest3)
-
-        completion([(initialRetainCount1, resultRetainCount1),
-                    (initialRetainCount2, resultRetainCount2),
-                    (initialRetainCount3, resultRetainCount3)])
     }
 }
 

--- a/Tests/AssignToManyTests.swift
+++ b/Tests/AssignToManyTests.swift
@@ -13,56 +13,138 @@ import CombineExt
 
 @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 class AssignToManyTests: XCTestCase {
+    private typealias RetainCheckCompletion = ([(initialRetainCount: Int, resultRetainCount: Int)]) -> Void
+
     var subscription: AnyCancellable!
+
     func testAssignToTwo() {
         let source = PassthroughSubject<Int, Never>()
-        let dest1 = Fake1(prop: 0)
-        let dest2 = Fake2(ivar: 0)
-        
-        XCTAssertEqual(dest1.prop, 0)
-        XCTAssertEqual(dest2.ivar, 0)
-        
-        subscription = source
-            .assign(to: \.prop, on: dest1,
-                    and: \.ivar, on: dest2)
-            
-        source.send(4)
-        XCTAssertEqual(dest1.prop, 4)
-        XCTAssertEqual(dest2.ivar, 4)
-        
-        source.send(12)
-        XCTAssertEqual(dest1.prop, 12)
-        XCTAssertEqual(dest2.ivar, 12)
-        
-        source.send(-7)
-        XCTAssertEqual(dest1.prop, -7)
-        XCTAssertEqual(dest2.ivar, -7)
+
+        for ownership in [ObjectOwnership.strong, .weak, .unowned] {
+            let dest1 = Fake1(prop: 0)
+            let dest2 = Fake2(ivar: 0)
+
+            XCTAssertEqual(dest1.prop, 0)
+            XCTAssertEqual(dest2.ivar, 0)
+
+            subscription = source
+                .assign(to: \.prop, on: dest1,
+                        and: \.ivar, on: dest2,
+                        ownership: ownership)
+
+            source.send(4)
+            XCTAssertEqual(dest1.prop, 4, "\(ownership) ownership")
+            XCTAssertEqual(dest2.ivar, 4, "\(ownership) ownership")
+
+            source.send(12)
+            XCTAssertEqual(dest1.prop, 12, "\(ownership) ownership")
+            XCTAssertEqual(dest2.ivar, 12, "\(ownership) ownership")
+
+            source.send(-7)
+            XCTAssertEqual(dest1.prop, -7, "\(ownership) ownership")
+            XCTAssertEqual(dest2.ivar, -7, "\(ownership) ownership")
+        }
     }
     
     func testAssignToThree() {
         let source = PassthroughSubject<String, Never>()
+
+        for ownership in [ObjectOwnership.strong, .weak, .unowned] {
+            let dest1 = Fake1(prop: "")
+            let dest2 = Fake2(ivar: "")
+            let dest3 = Fake3(value: "") { String(repeating: $0, count: $0.count) }
+
+            XCTAssertEqual(dest1.prop, "")
+            XCTAssertEqual(dest2.ivar, "")
+            XCTAssertEqual(dest3.value, "")
+
+            subscription = source
+                .assign(to: \.prop, on: dest1,
+                        and: \.ivar, on: dest2,
+                        and: \.value, on: dest3,
+                        ownership: ownership)
+
+            source.send("Hello")
+            XCTAssertEqual(dest1.prop, "Hello", "\(ownership) ownership")
+            XCTAssertEqual(dest2.ivar, "Hello", "\(ownership) ownership")
+            XCTAssertEqual(dest3.value, "HelloHelloHelloHelloHello", "\(ownership) ownership")
+
+            source.send("Meh")
+            XCTAssertEqual(dest1.prop, "Meh", "\(ownership) ownership")
+            XCTAssertEqual(dest2.ivar, "Meh", "\(ownership) ownership")
+            XCTAssertEqual(dest3.value, "MehMehMeh", "\(ownership) ownership")
+        }
+    }
+
+    func testWeakOwnership() {
+        let completion: RetainCheckCompletion = {
+            $0.forEach {
+                XCTAssertEqual($0.initialRetainCount, $0.resultRetainCount)
+            }
+        }
+        checkAssign2RetainValue(for: .weak, completion: completion)
+        checkAssign3RetainValue(for: .weak, completion: completion)
+    }
+
+    func testUnownedOwnership() {
+        let completion: RetainCheckCompletion = {
+            $0.forEach {
+                XCTAssertEqual($0.initialRetainCount, $0.resultRetainCount)
+            }
+        }
+        checkAssign2RetainValue(for: .unowned, completion: completion)
+        checkAssign3RetainValue(for: .unowned, completion: completion)
+    }
+
+    func testStrongOwnership() {
+        let completion: RetainCheckCompletion = {
+            $0.forEach {
+                XCTAssertEqual($0.initialRetainCount + 1, $0.resultRetainCount)
+            }
+        }
+        checkAssign2RetainValue(for: .strong, completion: completion)
+        checkAssign3RetainValue(for: .strong, completion: completion)
+    }
+
+    private func checkAssign2RetainValue(for ownership: ObjectOwnership, completion: RetainCheckCompletion) {
+        let source = PassthroughSubject<Int, Never>()
+        let dest1 = Fake1(prop: 0)
+        let dest2 = Fake2(ivar: 0)
+        let initialRetainCount1 = CFGetRetainCount(dest1)
+        let initialRetainCount2 = CFGetRetainCount(dest2)
+
+        subscription = source
+            .assign(to: \.prop, on: dest1, and: \.ivar, on: dest2, ownership: ownership)
+
+        let resultRetainCount1 = CFGetRetainCount(dest1)
+        let resultRetainCount2 = CFGetRetainCount(dest2)
+
+        completion([(initialRetainCount1, resultRetainCount1),
+                    (initialRetainCount2, resultRetainCount2)])
+    }
+
+    private func checkAssign3RetainValue(for ownership: ObjectOwnership, completion: RetainCheckCompletion) {
+        let source = PassthroughSubject<String, Never>()
         let dest1 = Fake1(prop: "")
         let dest2 = Fake2(ivar: "")
         let dest3 = Fake3(value: "") { String(repeating: $0, count: $0.count) }
-        
-        XCTAssertEqual(dest1.prop, "")
-        XCTAssertEqual(dest2.ivar, "")
-        XCTAssertEqual(dest3.value, "")
-        
+        let initialRetainCount1 = CFGetRetainCount(dest1)
+        let initialRetainCount2 = CFGetRetainCount(dest2)
+        let initialRetainCount3 = CFGetRetainCount(dest3)
+
         subscription = source
             .assign(to: \.prop, on: dest1,
                     and: \.ivar, on: dest2,
-                    and: \.value, on: dest3)
-            
-        source.send("Hello")
-        XCTAssertEqual(dest1.prop, "Hello")
-        XCTAssertEqual(dest2.ivar, "Hello")
-        XCTAssertEqual(dest3.value, "HelloHelloHelloHelloHello")
-        
-        source.send("Meh")
-        XCTAssertEqual(dest1.prop, "Meh")
-        XCTAssertEqual(dest2.ivar, "Meh")
-        XCTAssertEqual(dest3.value, "MehMehMeh")
+                    and: \.value, on: dest3,
+                    ownership: ownership)
+
+        let resultRetainCount1 = CFGetRetainCount(dest1)
+        let resultRetainCount2 = CFGetRetainCount(dest2)
+        let resultRetainCount3 = CFGetRetainCount(dest3)
+
+        completion([(initialRetainCount1, resultRetainCount1),
+                    (initialRetainCount2, resultRetainCount2),
+                    (initialRetainCount3, resultRetainCount3)])
     }
 }
 


### PR DESCRIPTION
Using `assign(to:)` might produce a memory leak because it creates a strong reference to `object` (there is a great topic on [swift forums](https://forums.swift.org/t/does-assign-to-produce-memory-leaks/29546/2) about this). I think it might be useful to have `assignWeakly(to:)` operator as part of CombineExt.