### PR TITLE
Add CURRENT_PROJECT_VERSION to target

### DIFF
--- a/CombineExt.xcodeproj/project.pbxproj
+++ b/CombineExt.xcodeproj/project.pbxproj
@@ -469,6 +469,7 @@
 		OBJ_19 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -497,6 +498,7 @@
 		OBJ_20 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
Appstore will reject app submission because `CFBundleVersion` is not available in the `info.plist` of the most current release binary `1.2.0`, this because the project is missing `CURRENT_PROJECT_VERSION`. 