### PR TITLE
Fixed issue with CurrentValueRelay and PassthroughRelay subscription

### DIFF
--- a/Sources/Relays/CurrentValueRelay.swift
+++ b/Sources/Relays/CurrentValueRelay.swift
@@ -46,6 +46,10 @@ public class CurrentValueRelay<Output>: Relay {
         publisher.subscribe(storage)
     }
 
+    public func subscribe<P: Relay>(_ publisher: P) -> AnyCancellable where Output == P.Output {
+        publisher.subscribe(storage)
+    }
+
     deinit {
         // Send a finished event upon dealloation
         subscriptions.forEach { $0.forceFinish() }

--- a/Sources/Relays/PassthroughRelay.swift
+++ b/Sources/Relays/PassthroughRelay.swift
@@ -45,6 +45,10 @@ public class PassthroughRelay<Output>: Relay {
         publisher.subscribe(storage)
     }
 
+    public func subscribe<P: Relay>(_ publisher: P) -> AnyCancellable where Output == P.Output {
+        publisher.subscribe(storage)
+    }
+
     deinit {
         // Send a finished event upon dealloation
         subscriptions.forEach { $0.forceFinish() }

--- a/Tests/CurrentValueRelayTests.swift
+++ b/Tests/CurrentValueRelayTests.swift
@@ -76,5 +76,27 @@ class CurrentValueRelayTests: XCTestCase {
         XCTAssertFalse(completed)
         XCTAssertEqual(values, ["initial", "1", "2", "3"])
     }
+
+    func testSubscribePublisher2() {
+        var completed = false
+
+        let input = CurrentValueRelay<String>("initial")
+        let output = CurrentValueRelay<String>("initial")
+
+        input
+            .subscribe(output)
+            .store(in: &subscriptions)
+        output
+            .sink(receiveCompletion: { _ in completed = true },
+                  receiveValue: { self.values.append($0) })
+            .store(in: &subscriptions)
+
+        input.accept("1")
+        input.accept("2")
+        input.accept("3")
+
+        XCTAssertFalse(completed)
+        XCTAssertEqual(values, ["initial", "1", "2", "3"])
+    }
 }
 #endif

--- a/Tests/PassthroughRelayTests.swift
+++ b/Tests/PassthroughRelayTests.swift
@@ -91,5 +91,27 @@ class PassthroughRelayTests: XCTestCase {
         XCTAssertFalse(completed)
         XCTAssertEqual(values, ["1", "2", "3"])
     }
+
+    func testSubscribePublisher2() {
+        var completed = false
+
+        let input = PassthroughRelay<String>()
+        let output = PassthroughRelay<String>()
+
+        input
+            .subscribe(output)
+            .store(in: &subscriptions)
+        output
+            .sink(receiveCompletion: { _ in completed = true },
+                  receiveValue: { self.values.append($0) })
+            .store(in: &subscriptions)
+
+        input.accept("1")
+        input.accept("2")
+        input.accept("3")
+
+        XCTAssertFalse(completed)
+        XCTAssertEqual(values, ["1", "2", "3"])
+    }
 }
 #endif


### PR DESCRIPTION
Fix for https://github.com/CombineCommunity/CombineExt/issues/37

I've added two new unit tests to confirm this issue. It seems that when you try to subscribe one relay to another
```swift
let input = CurrentValueRelay<String>("initial")
let output = CurrentValueRelay<String>("initial")

input
    .subscribe(output)
    .store(in: &subscriptions)
output
    .sink(receiveCompletion: { _ in completed = true }, receiveValue: { self.values.append($0) })
    .store(in: &subscriptions)

input.accept("1")
input.accept("2")
input.accept("3")

XCTAssertFalse(completed)
XCTAssertEqual(values, ["initial", "1", "2", "3"])
```
`subscribe()` doesn't work because the test fails. You can confirm it by replacing `subscribe()` with `sink { output.accept($0) }`
```swift
let input = CurrentValueRelay<String>("initial")
let output = CurrentValueRelay<String>("initial")

input
    .sink { output.accept($0) }
    .store(in: &subscriptions)
output
    .sink(receiveCompletion: { _ in completed = true }, receiveValue: { self.values.append($0) })
    .store(in: &subscriptions)

input.accept("1")
input.accept("2")
input.accept("3")

XCTAssertFalse(completed)
XCTAssertEqual(values, ["initial", "1", "2", "3"])
```