### PR TITLE
Adds `ignoreOutput(setOutputType:)` overload.

### DIFF
--- a/CombineExt.xcodeproj/project.pbxproj
+++ b/CombineExt.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		BF330EF624F1FFFE001281FC /* CombineSchedulers in Frameworks */ = {isa = PBXBuildFile; productRef = BF330EF524F1FFFE001281FC /* CombineSchedulers */; };
 		BF330EF924F20032001281FC /* Timer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF330EF824F20032001281FC /* Timer.swift */; };
 		BF330EFB24F20080001281FC /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF330EFA24F20080001281FC /* Lock.swift */; };
+		BF43CC1525008B4F005AFA28 /* IgnoreOutputSetOutputType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF43CC1425008B4F005AFA28 /* IgnoreOutputSetOutputType.swift */; };
+		BF43CC1725008C45005AFA28 /* IgnoreOutputSetOutputTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF43CC1625008C45005AFA28 /* IgnoreOutputSetOutputTypeTests.swift */; };
 		C387777C24E6BBE900FAD2D8 /* Nwise.swift in Sources */ = {isa = PBXBuildFile; fileRef = C387777B24E6BBE900FAD2D8 /* Nwise.swift */; };
 		C387777F24E6BF8F00FAD2D8 /* NwiseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C387777D24E6BF6C00FAD2D8 /* NwiseTests.swift */; };
 		D836234824EA9446002353AC /* MergeMany.swift in Sources */ = {isa = PBXBuildFile; fileRef = D836234724EA9446002353AC /* MergeMany.swift */; };
@@ -100,6 +102,8 @@
 /* Begin PBXFileReference section */
 		BF330EF824F20032001281FC /* Timer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Timer.swift; sourceTree = "<group>"; };
 		BF330EFA24F20080001281FC /* Lock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
+		BF43CC1425008B4F005AFA28 /* IgnoreOutputSetOutputType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IgnoreOutputSetOutputType.swift; sourceTree = "<group>"; };
+		BF43CC1625008C45005AFA28 /* IgnoreOutputSetOutputTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IgnoreOutputSetOutputTypeTests.swift; sourceTree = "<group>"; };
 		C387777B24E6BBE900FAD2D8 /* Nwise.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Nwise.swift; sourceTree = "<group>"; };
 		C387777D24E6BF6C00FAD2D8 /* NwiseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NwiseTests.swift; sourceTree = "<group>"; };
 		"CombineExt::CombineExt::Product" /* CombineExt.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = CombineExt.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -237,6 +241,7 @@
 				OBJ_27 /* PrefixDuration.swift */,
 				OBJ_28 /* RemoveAllDuplicates.swift */,
 				OBJ_29 /* SetOutputType.swift */,
+				BF43CC1425008B4F005AFA28 /* IgnoreOutputSetOutputType.swift */,
 				OBJ_30 /* ShareReplay.swift */,
 				OBJ_31 /* Toggle.swift */,
 				OBJ_32 /* WithLatestFrom.swift */,
@@ -285,6 +290,7 @@
 				OBJ_55 /* RemoveAllDuplicatesTests.swift */,
 				OBJ_56 /* ReplaySubjectTests.swift */,
 				OBJ_57 /* SetOutputTypeTests.swift */,
+				BF43CC1625008C45005AFA28 /* IgnoreOutputSetOutputTypeTests.swift */,
 				OBJ_58 /* ShareReplayTests.swift */,
 				OBJ_59 /* ToggleTests.swift */,
 				OBJ_60 /* WithLatestFromTests.swift */,
@@ -544,6 +550,7 @@
 				OBJ_139 /* ShareReplayTests.swift in Sources */,
 				OBJ_140 /* ToggleTests.swift in Sources */,
 				OBJ_141 /* WithLatestFromTests.swift in Sources */,
+				BF43CC1725008C45005AFA28 /* IgnoreOutputSetOutputTypeTests.swift in Sources */,
 				OBJ_142 /* ZipManyTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -569,6 +576,7 @@
 				OBJ_91 /* MapMany.swift in Sources */,
 				OBJ_92 /* Materialize.swift in Sources */,
 				D836234824EA9446002353AC /* MergeMany.swift in Sources */,
+				BF43CC1525008B4F005AFA28 /* IgnoreOutputSetOutputType.swift in Sources */,
 				OBJ_93 /* Partition.swift in Sources */,
 				OBJ_94 /* PrefixDuration.swift in Sources */,
 				OBJ_95 /* RemoveAllDuplicates.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ All operators, utilities and helpers respect Combine's publisher contract, inclu
 * [prefix(duration:tolerance:​on:options:)](#prefixduration)
 * [toggle()](#toggle)
 * [nwise(_:) and pairwise()](#nwise)
+* [ignoreOutput(setOutputType:)](#ignoreOutputsetOutputType)
 
 ### Publishers
 * [AnyPublisher.create](#AnypublisherCreate)
@@ -618,6 +619,15 @@ subject.send(5)
 4 -> 5
 ```
 
+### ignoreOutput(setOutputType:)
+
+Shorthand for both ignoring a publisher’s value events and re-writing its `Output` generic.
+
+```swift
+let onlyAFour = ["1", "2", "3"].publisher
+  .ignoreOutput(setOutputType: Int.self)
+  .append(4)
+```
 
 ## Publishers
 

--- a/Sources/Operators/IgnoreOutputSetOutputType.swift
+++ b/Sources/Operators/IgnoreOutputSetOutputType.swift
@@ -1,0 +1,23 @@
+//
+//  IgnoreOutputSetOutputType.swift
+//  CombineExt
+//
+//  Created by Jasdev Singh on 02/09/2020.
+//  Copyright © 2020 Combine Community. All rights reserved.
+//
+
+#if canImport(Combine)
+import Combine
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+public extension Publisher {
+    /// An `ignoreOutput` overload that allows for setting a new output type.
+    ///
+    /// - parameter outputType: The new output type for downstream.
+    ///
+    /// - returns: A publisher that ignores upstream value events and sets its output generic to `NewOutput`.
+    func ignoreOutput<NewOutput>(setOutputType to: NewOutput.Type) -> Publishers.Map<Publishers.IgnoreOutput<Self>, NewOutput> {
+        ignoreOutput().map { _ -> NewOutput in }
+    }
+}
+#endif

--- a/Tests/IgnoreOutputSetOutputTypeTests.swift
+++ b/Tests/IgnoreOutputSetOutputTypeTests.swift
@@ -1,0 +1,25 @@
+//
+//  IgnoreOutputSetOutputTypeTests.swift
+//  CombineExtTests
+//
+//  Created by Jasdev Singh on 02/09/2020.
+//  Copyright © 2020 Combine Community. All rights reserved.
+//
+
+#if !os(watchOS)
+import XCTest
+import Combine
+import CombineExt
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+final class IgnoreOutputSetOutputTypeTests: XCTestCase {
+    func testIgnoreOutputSetOutputType() {
+        let publisher = Just("someString")
+            .ignoreOutput(setOutputType: Int.self)
+            .eraseToAnyPublisher()
+
+        XCTAssertTrue(type(of: publisher) == AnyPublisher<Int, Never>.self)
+    }
+}
+#endif
+


### PR DESCRIPTION
@mbrandonw brought up a handy overload on `ignoreOutput` [in a discussion](https://github.com/pointfreeco/swift-composable-architecture/issues/271#issuecomment-682599562) over in TCA’s repository. I’d also be up for adding `ignoreFailure` and `ignoreFailure(setFailureType:)`, if you see fit.