### PR TITLE
Adds ignoreFailure(completeImmediately:) and ignoreFailure(setFailureType:completeImmediately:).

### DIFF
--- a/CombineExt.xcodeproj/project.pbxproj
+++ b/CombineExt.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		BF330EF624F1FFFE001281FC /* CombineSchedulers in Frameworks */ = {isa = PBXBuildFile; productRef = BF330EF524F1FFFE001281FC /* CombineSchedulers */; };
 		BF330EF924F20032001281FC /* Timer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF330EF824F20032001281FC /* Timer.swift */; };
 		BF330EFB24F20080001281FC /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF330EFA24F20080001281FC /* Lock.swift */; };
+		BF3D3B5D253B83F300D830ED /* IgnoreFailure.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF3D3B5C253B83F300D830ED /* IgnoreFailure.swift */; };
+		BF3D3B67253B88E500D830ED /* IgnoreFailureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF3D3B66253B88E500D830ED /* IgnoreFailureTests.swift */; };
 		BF43CC1525008B4F005AFA28 /* IgnoreOutputSetOutputType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF43CC1425008B4F005AFA28 /* IgnoreOutputSetOutputType.swift */; };
 		BF43CC1725008C45005AFA28 /* IgnoreOutputSetOutputTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF43CC1625008C45005AFA28 /* IgnoreOutputSetOutputTypeTests.swift */; };
 		C387777C24E6BBE900FAD2D8 /* Nwise.swift in Sources */ = {isa = PBXBuildFile; fileRef = C387777B24E6BBE900FAD2D8 /* Nwise.swift */; };
@@ -106,6 +108,8 @@
 		1970A8B32524730400799AB6 /* FilterManyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterManyTests.swift; sourceTree = "<group>"; };
 		BF330EF824F20032001281FC /* Timer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Timer.swift; sourceTree = "<group>"; };
 		BF330EFA24F20080001281FC /* Lock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
+		BF3D3B5C253B83F300D830ED /* IgnoreFailure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IgnoreFailure.swift; sourceTree = "<group>"; };
+		BF3D3B66253B88E500D830ED /* IgnoreFailureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IgnoreFailureTests.swift; sourceTree = "<group>"; };
 		BF43CC1425008B4F005AFA28 /* IgnoreOutputSetOutputType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IgnoreOutputSetOutputType.swift; sourceTree = "<group>"; };
 		BF43CC1625008C45005AFA28 /* IgnoreOutputSetOutputTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IgnoreOutputSetOutputTypeTests.swift; sourceTree = "<group>"; };
 		C387777B24E6BBE900FAD2D8 /* Nwise.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Nwise.swift; sourceTree = "<group>"; };
@@ -246,6 +250,7 @@
 				OBJ_28 /* RemoveAllDuplicates.swift */,
 				OBJ_29 /* SetOutputType.swift */,
 				BF43CC1425008B4F005AFA28 /* IgnoreOutputSetOutputType.swift */,
+				BF3D3B5C253B83F300D830ED /* IgnoreFailure.swift */,
 				OBJ_30 /* ShareReplay.swift */,
 				OBJ_31 /* Toggle.swift */,
 				OBJ_32 /* WithLatestFrom.swift */,
@@ -297,6 +302,7 @@
 				OBJ_56 /* ReplaySubjectTests.swift */,
 				OBJ_57 /* SetOutputTypeTests.swift */,
 				BF43CC1625008C45005AFA28 /* IgnoreOutputSetOutputTypeTests.swift */,
+				BF3D3B66253B88E500D830ED /* IgnoreFailureTests.swift */,
 				OBJ_58 /* ShareReplayTests.swift */,
 				OBJ_59 /* ToggleTests.swift */,
 				OBJ_60 /* WithLatestFromTests.swift */,
@@ -540,6 +546,7 @@
 				1970A8B42524730500799AB6 /* FilterManyTests.swift in Sources */,
 				D836234A24EA9888002353AC /* MergeManyTests.swift in Sources */,
 				OBJ_125 /* CombineLatestManyTests.swift in Sources */,
+				BF3D3B67253B88E500D830ED /* IgnoreFailureTests.swift in Sources */,
 				OBJ_126 /* CreateTests.swift in Sources */,
 				OBJ_127 /* CurrentValueRelayTests.swift in Sources */,
 				C387777F24E6BF8F00FAD2D8 /* NwiseTests.swift in Sources */,
@@ -575,6 +582,7 @@
 				OBJ_84 /* Amb.swift in Sources */,
 				OBJ_85 /* AssignOwnership.swift in Sources */,
 				OBJ_86 /* AssignToMany.swift in Sources */,
+				BF3D3B5D253B83F300D830ED /* IgnoreFailure.swift in Sources */,
 				BF330EFB24F20080001281FC /* Lock.swift in Sources */,
 				OBJ_87 /* CombineLatestMany.swift in Sources */,
 				OBJ_88 /* Create.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ All operators, utilities and helpers respect Combine's publisher contract, inclu
 * [toggle()](#toggle)
 * [nwise(_:) and pairwise()](#nwise)
 * [ignoreOutput(setOutputType:)](#ignoreOutputsetOutputType)
+* [ignoreFailure](#ignoreFailure)
 
 ### Publishers
 * [AnyPublisher.create](#AnypublisherCreate)
@@ -649,6 +650,37 @@ Shorthand for both ignoring a publisher’s value events and re-writing its `Out
 let onlyAFour = ["1", "2", "3"].publisher
   .ignoreOutput(setOutputType: Int.self)
   .append(4)
+```
+
+### ignoreFailure
+
+CombineExt provides a couple of overloads to ignore errors and optionally specify a new error type and whether to trigger completions in such cases.
+
+- `ignoreFailure(completeImmediately:)`
+- `ignoreFailure(setFailureType:completeImmediately:)`
+
+```swift
+enum AnError {
+  case someError 
+}
+
+let subject = PassthroughSubject<Int, AnError>()
+
+subscription = subject
+  .ignoreFailure() // The `completeImmediately` parameter defaults to `true`.
+  .sink(receiveValue: { print($0) }, receiveCompletion: { print($0) })
+
+subject.send(1)
+subject.send(2)
+subject.send(3)
+subject.send(completion: .failure(.someError))
+```
+
+```none
+1
+2
+3
+.finished
 ```
 
 ## Publishers

--- a/Sources/Operators/IgnoreFailure.swift
+++ b/Sources/Operators/IgnoreFailure.swift
@@ -1,0 +1,38 @@
+//
+//  IgnoreFailure.swift
+//  CombineExt
+//
+//  Created by Jasdev Singh on 17/10/2020.
+//  Copyright © 2020 Combine Community. All rights reserved.
+//
+
+#if canImport(Combine)
+import Combine
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+public extension Publisher {
+    /// An analog to `ignoreOutput` for `Publisher`’s `Failure` generic, allowing for either no or an immediate completion on an error event.
+    ///
+    /// - parameter completeImmediately: Whether the returned publisher should complete on an error event. Defaults to `true`.
+    ///
+    /// - returns: A publisher that ignores upstream error events.
+    func ignoreFailure(completeImmediately: Bool = true) -> AnyPublisher<Output, Never> {
+        `catch` { _ in Empty(completeImmediately: completeImmediately) }
+            .eraseToAnyPublisher()
+    }
+
+    /// An `ignoreFailure` overload that also allows for setting a new failure type.
+    ///
+    /// - parameter setFailureType: The failure type of the returned publisher.
+    /// - parameter completeImmediately: Whether the returned publisher should complete on an error event. Defaults to `true`.
+    ///
+    /// - returns: A publisher that ignores upstream error events and has its `Failure` generic pinned to the specified failure type.
+    func ignoreFailure<NewFailure: Error>(
+        setFailureType newFailureType: NewFailure.Type,
+        completeImmediately: Bool = true) -> AnyPublisher<Output, NewFailure> {
+        ignoreFailure(completeImmediately: completeImmediately)
+            .setFailureType(to: newFailureType)
+            .eraseToAnyPublisher()
+    }
+}
+#endif

--- a/Sources/Operators/IgnoreOutputSetOutputType.swift
+++ b/Sources/Operators/IgnoreOutputSetOutputType.swift
@@ -13,10 +13,10 @@ import Combine
 public extension Publisher {
     /// An `ignoreOutput` overload that allows for setting a new output type.
     ///
-    /// - parameter outputType: The new output type for downstream.
+    /// - parameter setOutputType: The new output type for downstream.
     ///
     /// - returns: A publisher that ignores upstream value events and sets its output generic to `NewOutput`.
-    func ignoreOutput<NewOutput>(setOutputType to: NewOutput.Type) -> Publishers.Map<Publishers.IgnoreOutput<Self>, NewOutput> {
+    func ignoreOutput<NewOutput>(setOutputType newOutputType: NewOutput.Type) -> Publishers.Map<Publishers.IgnoreOutput<Self>, NewOutput> {
         ignoreOutput().map { _ -> NewOutput in }
     }
 }

--- a/Tests/IgnoreFailureTests.swift
+++ b/Tests/IgnoreFailureTests.swift
@@ -1,0 +1,131 @@
+//
+//  IgnoreFailureTests.swift
+//  CombineExtTests
+//
+//  Created by Jasdev Singh on 17/10/20.
+//  Copyright © 2020 Combine Community. All rights reserved.
+//
+
+#if !os(watchOS)
+import XCTest
+import Combine
+import CombineExt
+import CombineSchedulers
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+final class IgnoreFailureTests: XCTestCase {
+    private var cancellable: AnyCancellable!
+
+    func testIgnoreFailure() {
+        let publisher = Just("someString")
+            .setFailureType(to: Error.self)
+            .ignoreFailure() // `Never` out the above failure type.
+            .eraseToAnyPublisher()
+
+        XCTAssertTrue(type(of: publisher) == AnyPublisher<String, Never>.self)
+    }
+
+    private enum TestError: Error {
+        case anError
+    }
+
+    func testIgnoreFailureErrorEventCompleteImmediately() {
+        let subject = PassthroughSubject<Int, TestError>()
+
+        var values = [Int]()
+        var completions = [Subscribers.Completion<Never>]()
+
+        cancellable = subject
+            .ignoreFailure()
+            .sink(
+                receiveCompletion: { completions.append($0) },
+                receiveValue: { values.append($0) })
+
+        subject.send(1)
+        subject.send(2)
+        subject.send(3)
+
+        subject.send(completion: .failure(.anError))
+
+        XCTAssertEqual([1, 2, 3], values)
+        XCTAssertEqual([.finished], completions)
+    }
+
+    func testIgnoreFailureErrorEventNoCompletion() {
+        let subject = PassthroughSubject<Int, TestError>()
+
+        var values = [Int]()
+        var completions = [Subscribers.Completion<Never>]()
+
+        cancellable = subject
+            .ignoreFailure(completeImmediately: false)
+            .sink(
+                receiveCompletion: { completions.append($0) },
+                receiveValue: { values.append($0) })
+
+        subject.send(1)
+        subject.send(2)
+        subject.send(3)
+
+        subject.send(completion: .failure(.anError))
+
+        XCTAssertEqual([1, 2, 3], values)
+        XCTAssertTrue(completions.isEmpty)
+    }
+
+    private enum AnotherTestError: Error, Equatable {
+        case anotherError
+    }
+
+    func testIgnoreFailureSetFailureTypeCompleteImmediately() {
+        let subject = PassthroughSubject<Int, TestError>()
+
+        var values = [Int]()
+        var completions = [Subscribers.Completion<AnotherTestError>]()
+
+        let newPublisher = subject
+            .ignoreFailure(setFailureType: AnotherTestError.self)
+            .eraseToAnyPublisher()
+
+        XCTAssertTrue(type(of: newPublisher) == AnyPublisher<Int, AnotherTestError>.self)
+
+        cancellable = newPublisher
+            .sink(
+                receiveCompletion: { completions.append($0) },
+                receiveValue: { values.append($0) })
+
+        subject.send(1)
+        subject.send(2)
+        subject.send(3)
+
+        subject.send(completion: .failure(.anError))
+
+        XCTAssertEqual([1, 2, 3], values)
+        XCTAssertEqual([.finished], completions)
+    }
+
+    func testIgnoreFailureSetFailureTypeNoCompletion() {
+        let subject = PassthroughSubject<Int, TestError>()
+
+        var values = [Int]()
+        var completions = [Subscribers.Completion<AnotherTestError>]()
+
+        let newPublisher = subject
+            .ignoreFailure(setFailureType: AnotherTestError.self, completeImmediately: false)
+
+        cancellable = newPublisher
+            .sink(
+                receiveCompletion: { completions.append($0) },
+                receiveValue: { values.append($0) })
+
+        subject.send(1)
+        subject.send(2)
+        subject.send(3)
+
+        subject.send(completion: .failure(.anError))
+
+        XCTAssertEqual([1, 2, 3], values)
+        XCTAssertTrue(completions.isEmpty)
+    }
+}
+#endif


### PR DESCRIPTION
Mirroring `ignoreOutput` and `ignoreOutput(setOutputType:)` for the `Failure` generic. h/t @mbrandonw @stephencelis for [their discussion on this](https://github.com/pointfreeco/swift-composable-architecture/issues/271#issuecomment-682599562) and the feedback they filed (FB8563288).