### PR TITLE
Adds ConcatMap operator

### DIFF
--- a/Sources/Common/DemandBuffer.swift
+++ b/Sources/Common/DemandBuffer.swift
@@ -27,6 +27,11 @@ class DemandBuffer<S: Subscriber> {
     private var completion: Subscribers.Completion<S.Failure>?
     private var demandState = Demand()
 
+    /// The remaining demand, i.e. the number of values the subscriber still expects
+    var remainingDemand: Subscribers.Demand {
+        demandState.requested - demandState.sent
+    }
+
     /// Initialize a new demand buffer for a provided downstream subscriber
     ///
     /// - parameter subscriber: The downstream subscriber demanding events
@@ -70,7 +75,7 @@ class DemandBuffer<S: Subscriber> {
 
     /// Signal to the buffer that the downstream requested new demand
     ///
-    /// - note: The buffer will attempt to flush as many events rqeuested
+    /// - note: The buffer will attempt to flush as many events requested
     ///         by the downstream at this point
     func demand(_ demand: Subscribers.Demand) -> Subscribers.Demand {
         flush(adding: demand)
@@ -110,7 +115,7 @@ class DemandBuffer<S: Subscriber> {
             return .none
         }
 
-        let sentDemand = demandState.requested - demandState.sent
+        let sentDemand = remainingDemand
         demandState.sent += sentDemand
         return sentDemand
     }

--- a/Sources/Operators/ConcatMap.swift
+++ b/Sources/Operators/ConcatMap.swift
@@ -1,0 +1,27 @@
+//
+//  ConcatMap.swift
+//  CombineExt
+//
+//  Created by Daniel Peter on 22/11/2020.
+//  Copyright © 2020 Combine Community. All rights reserved.
+//
+
+#if canImport(Combine)
+import Combine
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+public extension Publisher {
+    /// Transforms an output value into a new publisher, and flattens the stream of events from these multiple upstream publishers to appear as if they were coming from a single stream of events.
+    ///
+    /// Mapping to a new publisher will keep the subscription to the previous one alive until it completes and only then subscribe to the new one. This also means that all values sent by the new publisher are not forwarded as long as the previous one hasn't completed.
+    ///
+    /// - parameter transform: A transform to apply to each emitted value, from which you can return a new Publisher
+    ///
+    /// - returns: A publisher emitting the values of all emitted publishers in order.
+    func concatMap<T, P>(
+        _ transform: @escaping (Self.Output) -> P
+    ) -> Publishers.FlatMap<P, Self> where T == P.Output, P: Publisher, Self.Failure == P.Failure {
+        flatMap(maxPublishers: .max(1), transform)
+    }
+}
+#endif

--- a/Sources/Operators/ConcatMap.swift
+++ b/Sources/Operators/ConcatMap.swift
@@ -8,6 +8,7 @@
 
 #if canImport(Combine)
 import Combine
+import class Foundation.NSRecursiveLock
 
 @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public extension Publisher {
@@ -20,8 +21,145 @@ public extension Publisher {
     /// - returns: A publisher emitting the values of all emitted publishers in order.
     func concatMap<T, P>(
         _ transform: @escaping (Self.Output) -> P
-    ) -> Publishers.FlatMap<P, Self> where T == P.Output, P: Publisher, Self.Failure == P.Failure {
-        flatMap(maxPublishers: .max(1), transform)
+    ) -> Publishers.ConcatMap<P, Self> where T == P.Output, P: Publisher, Self.Failure == P.Failure {
+        return Publishers.ConcatMap(upstream: self, transform: transform)
+    }
+}
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+public extension Publishers {
+    final class ConcatMap<NewPublisher, Upstream>: Publisher where NewPublisher: Publisher, Upstream: Publisher, NewPublisher.Failure == Upstream.Failure  {
+        public typealias Transform = (Upstream.Output) -> NewPublisher
+        public typealias Output = NewPublisher.Output
+        public typealias Failure = Upstream.Failure
+
+        public let upstream: Upstream
+        public let transform: Transform
+
+        public init(
+            upstream: Upstream,
+            transform: @escaping Transform
+        ) {
+            self.upstream = upstream
+            self.transform = transform
+        }
+
+        public func receive<S: Subscriber>(subscriber: S)
+        where Output == S.Input, Failure == S.Failure {
+            subscriber.receive(
+                subscription: Subscription(
+                    upstream: upstream,
+                    transform: transform,
+                    downstream: subscriber
+                )
+            )
+        }
+    }
+}
+
+// MARK: - Subscription
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+private extension Publishers.ConcatMap {
+    final class Subscription<Downstream: Subscriber>: Combine.Subscription where Downstream.Input == Output, Downstream.Failure == Failure {
+        private var sink: Sink<Downstream>?
+
+        init(
+            upstream: Upstream,
+            transform: @escaping Transform,
+            downstream: Downstream
+        ) {
+            self.sink = Sink(
+                upstream: upstream,
+                downstream: downstream,
+                transform: { transform($0) }
+            )
+        }
+
+        func request(_ demand: Subscribers.Demand) {
+            sink?.demand(demand)
+        }
+
+        func cancel() {
+            sink = nil
+        }
+    }
+}
+
+// MARK: - Sink
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+private extension Publishers.ConcatMap {
+    final class Sink<Downstream: Subscriber>: CombineExt.Sink<Upstream, Downstream>
+    where Downstream.Input == Output, Downstream.Failure == Failure {
+        private let lock = NSRecursiveLock()
+        private let transform: Transform
+        private var activePublisher: NewPublisher?
+        private var bufferedPublishers: [NewPublisher]
+        private var cancellables: Set<AnyCancellable>
+
+        init(
+            upstream: Upstream,
+            downstream: Downstream,
+            transform: @escaping Transform
+        ) {
+            self.transform = transform
+            self.bufferedPublishers = []
+            self.cancellables = []
+            super.init(
+                upstream: upstream,
+                downstream: downstream,
+                transformFailure: { $0 }
+            )
+        }
+
+        override func receive(_ input: Upstream.Output) -> Subscribers.Demand {
+            let mapped = transform(input)
+
+            lock.lock()
+            if activePublisher == nil {
+                lock.unlock()
+                setActivePublisher(mapped)
+            } else {
+                lock.unlock()
+                bufferedPublishers.append(mapped)
+            }
+
+            return .unlimited
+        }
+
+        private func setActivePublisher(_ publisher: NewPublisher) {
+            lock.lock()
+            defer { lock.unlock() }
+            activePublisher = publisher
+
+            publisher.sink(
+                receiveCompletion: { completion in
+                    switch completion {
+                    case .finished:
+                        self.lock.lock()
+                        guard let next = self.bufferedPublishers.first else {
+                            self.lock.unlock()
+                            return
+                        }
+                        self.bufferedPublishers.removeFirst()
+                        self.lock.unlock()
+                        self.setActivePublisher(next)
+                    case .failure(let error):
+                        self.receive(completion: .failure(error))
+                    }
+                },
+                receiveValue: { value in
+                    _ = self.buffer.buffer(value: value)
+                }
+            )
+            .store(in: &cancellables)
+        }
+    }
+}
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension Publishers.ConcatMap.Subscription: CustomStringConvertible {
+    var description: String {
+        return "ConcatMap.Subscription<\(Downstream.Input.self), \(Downstream.Failure.self)>"
     }
 }
 #endif

--- a/Sources/Operators/ConcatMap.swift
+++ b/Sources/Operators/ConcatMap.swift
@@ -28,7 +28,7 @@ public extension Publisher {
 
 @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public extension Publishers {
-    final class ConcatMap<NewPublisher, Upstream>: Publisher where NewPublisher: Publisher, Upstream: Publisher, NewPublisher.Failure == Upstream.Failure  {
+    struct ConcatMap<NewPublisher, Upstream>: Publisher where NewPublisher: Publisher, Upstream: Publisher, NewPublisher.Failure == Upstream.Failure  {
         public typealias Transform = (Upstream.Output) -> NewPublisher
         public typealias Output = NewPublisher.Output
         public typealias Failure = Upstream.Failure
@@ -88,8 +88,7 @@ private extension Publishers.ConcatMap {
 // MARK: - Sink
 @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 private extension Publishers.ConcatMap {
-    final class Sink<Downstream: Subscriber>: CombineExt.Sink<Upstream, Downstream>
-    where Downstream.Input == Output, Downstream.Failure == Failure {
+    final class Sink<Downstream: Subscriber>: CombineExt.Sink<Upstream, Downstream> where Downstream.Input == Output, Downstream.Failure == Failure {
         private let lock = NSRecursiveLock()
         private let transform: Transform
         private var activePublisher: NewPublisher?

--- a/Tests/ConcatMapTests.swift
+++ b/Tests/ConcatMapTests.swift
@@ -1,0 +1,104 @@
+//
+//  ConcatMapTests.swift
+//  CombineExtTests
+//
+//  Created by Daniel Peter on 22/11/2020.
+//  Copyright © 2020 Combine Community. All rights reserved.
+//
+
+#if !os(watchOS)
+import XCTest
+import Combine
+import CombineExt
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+final class ConcatMapTests: XCTestCase {
+    private enum TestError: Swift.Error {
+        case failure
+    }
+    private typealias P = PassthroughSubject<Int, TestError>
+    private var cancellables: Set<AnyCancellable>!
+
+    override func setUp() {
+        super.setUp()
+        cancellables = []
+    }
+
+    func test_publishes_values_inOrder() {
+        var receivedValues = [Int]()
+        let expectedValues = [1, 2, 3, 4]
+
+        let firstPublisher = P()
+        let secondPublisher = P()
+
+        let sut = PassthroughSubject<P, TestError>()
+
+        sut.concatMap { $0 }
+            .sink(
+                receiveCompletion: { _ in },
+                receiveValue: { value in receivedValues.append(value) }
+            )
+            .store(in: &cancellables)
+
+        sut.send(firstPublisher)
+        sut.send(secondPublisher)
+
+        firstPublisher.send(1)
+        firstPublisher.send(2)
+        firstPublisher.send(completion: .finished)
+
+        secondPublisher.send(3)
+        secondPublisher.send(4)
+        secondPublisher.send(completion: .finished)
+
+        XCTAssertEqual(expectedValues, receivedValues)
+    }
+
+    func test_completes_when_last_publisher_completes() {
+        var receivedCompletion: Subscribers.Completion<TestError>?
+
+        let firstPublisher = P()
+        let secondPublisher = P()
+
+        let sut = PassthroughSubject<P, TestError>()
+
+        sut.concatMap { $0 }
+            .sink(
+                receiveCompletion: { receivedCompletion = $0 },
+                receiveValue: { _ in }
+            )
+            .store(in: &cancellables)
+
+        sut.send(firstPublisher)
+        sut.send(secondPublisher)
+        firstPublisher.send(completion: .finished)
+        XCTAssertNil(receivedCompletion)
+        secondPublisher.send(completion: .finished)
+        XCTAssertNotNil(receivedCompletion)
+    }
+
+    func test_completes_with_failure_if_publisher_fails() {
+        let expectedCompletion = Subscribers.Completion<TestError>.failure(.failure)
+        var receivedCompletion: Subscribers.Completion<TestError>?
+
+        let firstPublisher = P()
+        let secondPublisher = P()
+
+        let sut = PassthroughSubject<P, TestError>()
+
+        sut.concatMap { $0 }
+            .sink(
+                receiveCompletion: { receivedCompletion = $0 },
+                receiveValue: { _ in }
+            )
+            .store(in: &cancellables)
+
+        sut.send(firstPublisher)
+        sut.send(secondPublisher)
+        firstPublisher.send(completion: .failure(.failure))
+        XCTAssertEqual(receivedCompletion, expectedCompletion)
+        secondPublisher.send(completion: .finished)
+        XCTAssertEqual(receivedCompletion, expectedCompletion)
+    }
+}
+#endif

--- a/Tests/ConcatMapTests.swift
+++ b/Tests/ConcatMapTests.swift
@@ -54,7 +54,7 @@ final class ConcatMapTests: XCTestCase {
         XCTAssertEqual(expectedValues, receivedValues)
     }
 
-    func test_completes_when_last_publisher_completes() {
+    func test_completes_when_upstream_completes() {
         var receivedCompletion: Subscribers.Completion<TestError>?
 
         let firstPublisher = P()
@@ -74,6 +74,8 @@ final class ConcatMapTests: XCTestCase {
         firstPublisher.send(completion: .finished)
         XCTAssertNil(receivedCompletion)
         secondPublisher.send(completion: .finished)
+        XCTAssertNil(receivedCompletion)
+        sut.send(completion: .finished)
         XCTAssertNotNil(receivedCompletion)
     }
 

--- a/Tests/ConcatMapTests.swift
+++ b/Tests/ConcatMapTests.swift
@@ -26,10 +26,11 @@ final class ConcatMapTests: XCTestCase {
 
     func test_publishes_values_inOrder() {
         var receivedValues = [Int]()
-        let expectedValues = [1, 2, 3, 4]
+        let expectedValues = [1, 2, 4, 5, 6]
 
         let firstPublisher = P()
         let secondPublisher = P()
+        let thirdPublisher = P()
 
         let sut = PassthroughSubject<P, TestError>()
 
@@ -42,14 +43,19 @@ final class ConcatMapTests: XCTestCase {
 
         sut.send(firstPublisher)
         sut.send(secondPublisher)
+        sut.send(thirdPublisher)
 
         firstPublisher.send(1)
         firstPublisher.send(2)
+        // values sent onto the second publisher will be ignored as long as the first publisher hasn't completed
+        secondPublisher.send(3)
         firstPublisher.send(completion: .finished)
 
-        secondPublisher.send(3)
         secondPublisher.send(4)
+        secondPublisher.send(5)
         secondPublisher.send(completion: .finished)
+
+        thirdPublisher.send(6)
 
         XCTAssertEqual(expectedValues, receivedValues)
     }


### PR DESCRIPTION
Resolves #41.

@freak4pc mentioned in #41, that we could try using `.flatMap(maxPublishers: 1, transform:)` to achieve the functionality of ConcatMap. I added some tests to verify if this is true, but unfortunately it's not that easy. ;) 

**Unexpected behaviour:**
* `.flatMap(maxPublishers: 1, transform:)` does not buffer mapped publishers, discarding all publishers if there is an active one, leading to missing values.