### PR TITLE
Add liftErrorFromResult and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,6 +719,37 @@ subscription = ints
 .finished
 ```
 
+### liftErrorFromResult
+
+Transforms a publisher of type `AnyPublisher<Result<T, E>, Never>` to `AnyPublisher<T, E>`
+
+```swift
+enum AnError: Error {
+    case someError
+}
+
+let subject = PassthroughSubject<Result<Int, AnError>, Never>()
+
+let subscription = subject
+    .liftErrorFromResult()
+    .sink(receiveCompletion: { print("completion: \($0)") },
+          receiveValue: { print("value: \($0)") })
+
+subject.send(.success(1))
+subject.send(.success(2))
+subject.send(.success(3))
+subject.send(.failure(.someError))
+```
+
+#### Output
+
+```none
+value: 1
+value: 2
+value: 3
+completion: failure(AnError.someError)
+```
+
 ## Publishers
 
 This section outlines some of the custom Combine publishers CombineExt provides

--- a/Sources/Operators/LiftErrorFromResult.swift
+++ b/Sources/Operators/LiftErrorFromResult.swift
@@ -9,24 +9,25 @@
 #if canImport(Combine)
 import Combine
 
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public extension Publisher where Self.Failure == Never {
     /// Transform a never-failing publisher with Result<T, E> as output
     /// to a new publisher that unwraps Result and sets T as Output and E as Failure
     /// - Returns: a type-erased publisher of type <T, E>
     func liftErrorFromResult<T, E>() -> AnyPublisher<T, E>
     where Output == Result<T, E> {
-        flatMap { (result: Result<T, E>) -> AnyPublisher<T, E> in
-            switch result {
-            case .success(let some):
-                return Just(some)
-                    .setFailureType(to: E.self)
-                    .eraseToAnyPublisher()
-            case .failure(let error):
-                return Fail(error: error)
-                    .eraseToAnyPublisher()
-            }
-        }.eraseToAnyPublisher()
+        setFailureType(to: E.self)
+            .flatMap { (result: Result<T, E>) -> AnyPublisher<T, E> in
+                switch result {
+                case .success(let some):
+                    return Just(some)
+                        .setFailureType(to: E.self)
+                        .eraseToAnyPublisher()
+                case .failure(let error):
+                    return Fail(error: error)
+                        .eraseToAnyPublisher()
+                }
+            }.eraseToAnyPublisher()
     }
 }
 

--- a/Sources/Operators/LiftErrorFromResult.swift
+++ b/Sources/Operators/LiftErrorFromResult.swift
@@ -1,0 +1,33 @@
+//
+//  LiftErrorFromResult.swift
+//  CombineExt
+//
+//  Created by Yurii Zadoianchuk on 12/03/2021.
+//  Copyright © 2021 Combine Community. All rights reserved.
+//
+
+#if canImport(Combine)
+import Combine
+
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+public extension Publisher where Self.Failure == Never {
+    /// Transform a never-failing publisher with Result<T, E> as output
+    /// to a new publisher that unwraps Result and sets T as Output and E as Failure
+    /// - Returns: a type-erased publisher of type <T, E>
+    func liftErrorFromResult<T, E>() -> AnyPublisher<T, E>
+    where Output == Result<T, E> {
+        flatMap { (result: Result<T, E>) -> AnyPublisher<T, E> in
+            switch result {
+            case .success(let some):
+                return Just(some)
+                    .setFailureType(to: E.self)
+                    .eraseToAnyPublisher()
+            case .failure(let e):
+                return Fail(error: e)
+                    .eraseToAnyPublisher()
+            }
+        }.eraseToAnyPublisher()
+    }
+}
+
+#endif

--- a/Sources/Operators/LiftErrorFromResult.swift
+++ b/Sources/Operators/LiftErrorFromResult.swift
@@ -22,8 +22,8 @@ public extension Publisher where Self.Failure == Never {
                 return Just(some)
                     .setFailureType(to: E.self)
                     .eraseToAnyPublisher()
-            case .failure(let e):
-                return Fail(error: e)
+            case .failure(let error):
+                return Fail(error: error)
                     .eraseToAnyPublisher()
             }
         }.eraseToAnyPublisher()

--- a/Tests/LiftErrorFromResultTests.swift
+++ b/Tests/LiftErrorFromResultTests.swift
@@ -1,0 +1,80 @@
+//
+//  LiftErrorFromResultTests.swift
+//  CombineExtTests
+//
+//  Created by Yurii Zadoianchuk on 12/03/2021.
+//  Copyright © 2021 Combine Community. All rights reserved.
+//
+
+#if !os(watchOS)
+import XCTest
+import Combine
+import CombineExt
+
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+
+class LiftErrorFromResultTests: XCTestCase {
+    var subscription: AnyCancellable!
+
+    enum LiftErrorFromResultError: Error {
+        case someError
+    }
+
+    func testLiftNoError() {
+        let subject = PassthroughSubject<Result<Int, LiftErrorFromResultError>, Never>()
+        let testInt = 5
+        var completion: Subscribers.Completion<LiftErrorFromResultError>? = nil
+        var result: Int? = nil
+
+        subscription = subject
+            .liftErrorFromResult()
+            .sink(receiveCompletion: { completion = $0 },
+                  receiveValue: { result = $0 })
+
+        subject.send(.success(testInt))
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!, testInt)
+        XCTAssertNil(completion)
+    }
+
+    func testLiftError() {
+        let subject = PassthroughSubject<Result<Int, LiftErrorFromResultError>, Never>()
+        let testError = LiftErrorFromResultError.someError
+        var completion: Subscribers.Completion<LiftErrorFromResultError>? = nil
+        var result: Int? = nil
+
+        subscription = subject
+            .liftErrorFromResult()
+            .sink(receiveCompletion: { completion = $0 },
+                  receiveValue: { result = $0 })
+
+        subject.send(.failure(testError))
+        XCTAssertNil(result)
+        XCTAssertNotNil(completion)
+        XCTAssert(completion! == .failure(testError))
+    }
+
+    func testLiftErrorMultipleResults() {
+        let subject = PassthroughSubject<Result<Int, LiftErrorFromResultError>, Never>()
+        let testInts = [5, 6, 7]
+        let testError = LiftErrorFromResultError.someError
+        var completions: [Subscribers.Completion<LiftErrorFromResultError>] = []
+        var results: [Int] = []
+
+        subscription = subject
+            .liftErrorFromResult()
+            .sink(receiveCompletion: { completions.append($0) },
+                  receiveValue: { results.append($0) })
+
+        subject.send(.success(testInts[0]))
+        subject.send(.success(testInts[1]))
+        subject.send(.success(testInts[2]))
+        subject.send(.failure(testError))
+
+        XCTAssertEqual(testInts, results)
+        XCTAssertEqual(completions.count, 1)
+        XCTAssertEqual(completions.first!, .failure(testError))
+    }
+}
+
+#endif

--- a/Tests/LiftErrorFromResultTests.swift
+++ b/Tests/LiftErrorFromResultTests.swift
@@ -11,8 +11,7 @@ import XCTest
 import Combine
 import CombineExt
 
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
-
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 class LiftErrorFromResultTests: XCTestCase {
     var subscription: AnyCancellable!
 


### PR DESCRIPTION
This PR adds a new operator liftErrorFromResult which allows transforming a Publisher that outputs values wrapped in a `Result<T, E>` and `Failure` of `Never` to a new publisher `AnyPublisher<T,E>`.  
A common use-case for this is when the we expect to work with Non-`Never` publishers,  but the underlying code is producing publishers that have `Output` and `Failure` wrapped in a `Result` 

This is a continuation (and an inverse operator) of #79 