### PR TITLE
Share replay leak

### DIFF
--- a/Sources/Subjects/ReplaySubject.swift
+++ b/Sources/Subjects/ReplaySubject.swift
@@ -137,6 +137,7 @@ extension ReplaySubject {
 
         func forwardCompletionToBuffer(_ completion: Subscribers.Completion<Failure>) {
             demandBuffer?.complete(completion: completion)
+            cancel()
         }
 
         func request(_ demand: Subscribers.Demand) {


### PR DESCRIPTION
Attempts to fix https://github.com/CombineCommunity/CombineExt/issues/85

I added a test that proved that the source publisher was retained after everything had been nilled out/released.

I then added the `cancel()` method call in the `forwardCompletionToBuffer` method inside ReplaySubject.Subscription as this causes the subscription to then be released.

As I mentioned in the issue I raised, I'm not familiar enough to know what the other implications of this could be (it seems to all work fine for me in my project) so would appreciate any help or comments.