### PR TITLE
Add additional locking in DemandBuffer to protect demandState

### DIFF
--- a/Sources/Common/DemandBuffer.swift
+++ b/Sources/Common/DemandBuffer.swift
@@ -44,6 +44,11 @@ class DemandBuffer<S: Subscriber> {
         precondition(self.completion == nil,
                      "How could a completed publisher sent values?! Beats me 🤷‍♂️")
 
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+
         switch demandState.requested {
         case .unlimited:
             return subscriber.receive(value)

--- a/Sources/Common/DemandBuffer.swift
+++ b/Sources/Common/DemandBuffer.swift
@@ -43,11 +43,8 @@ class DemandBuffer<S: Subscriber> {
     func buffer(value: S.Input) -> Subscribers.Demand {
         precondition(self.completion == nil,
                      "How could a completed publisher sent values?! Beats me 🤷‍♂️")
-
         lock.lock()
-        defer {
-            lock.unlock()
-        }
+        defer { lock.unlock() }
 
         switch demandState.requested {
         case .unlimited:


### PR DESCRIPTION
I've recently been building a feature where I'm setting up a publisher using `Publishers.Create` on the main thread, and then sending values to the generated subscriber from another thread (this might an unsupported use-case for this publisher, let me know if so!). When debugging the code with Thread Sanitizer I get a warning about an access race:

```
SUMMARY: ThreadSanitizer: Swift access race (MyProject:arm64+0x1014d7318) in DemandBuffer.buffer(value:)+0x7c0
```

Looking at the code I can see that a `NSRecursiveLock` is used to protect the `demandState` inside of the DemandBuffer, but only in the `flush()` function. Since the `demandState` property is also accessed from within the `buffer(value:)` function my hunch is that this too should be protected by the lock. The use of the lock here leads me to believe that my threading case might be valid, but again let me know if this isn't the case.

This PR adds locking to the `buffer(value:)` function. Tests all seem to pass, and Thread Sanitizer is no longer upset with my code 👍🏻 