### PR TITLE
Package.swift: bump swift-tools-version to 5.3 and hide tests dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 
 import PackageDescription
 
@@ -15,7 +15,12 @@ let package = Package(
     ],
     targets: [
         .target(name: "CombineExt", dependencies: [], path: "Sources"),
-        .testTarget(name: "CombineExtTests", dependencies: ["CombineExt", "CombineSchedulers"], path: "Tests"),
+        .testTarget(name: "CombineExtTests",
+                    dependencies: [
+                        "CombineExt",
+                        .product(name: "CombineSchedulers", package: "combine-schedulers")
+                    ],
+                    path: "Tests"),
     ],
     swiftLanguageVersions: [.v5]
 )


### PR DESCRIPTION
Hello!

This commit is meant to hide CombineSchedulers from the project using CombineExt.

Before it, a project would import:
![Screen Shot 2021-07-12 at 15 05 32](https://user-images.githubusercontent.com/3480946/125344684-97806000-e325-11eb-95b7-0ecb63285f99.png)

After this commit, a project now imports:
![Screen Shot 2021-07-12 at 15 05 08](https://user-images.githubusercontent.com/3480946/125344714-a1a25e80-e325-11eb-8384-0e0510fc3504.png)

In order to do so, we bumped swift-tools-version to 5.3 and altered the test target expression.

Please note that I am not a Package.swift nor a SPM expert, comments and feedbacks will be very appreciated. 

Thank you!