### PR TITLE
Fix issue in ShareReplay publisher Switch to removing subscriptions after completion is sent

### DIFF
--- a/Sources/Subjects/ReplaySubject.swift
+++ b/Sources/Subjects/ReplaySubject.swift
@@ -72,6 +72,7 @@ public final class ReplaySubject<Output, Failure: Error>: Subject {
         }
 
         subscriptions.forEach { $0.forwardCompletionToBuffer(completion) }
+        self.subscriptions.removeAll()
     }
 
     public func send(subscription: Combine.Subscription) {
@@ -138,7 +139,6 @@ extension ReplaySubject {
 
         func forwardCompletionToBuffer(_ completion: Subscribers.Completion<Failure>) {
             demandBuffer?.complete(completion: completion)
-            cancel()
         }
 
         func request(_ demand: Subscribers.Demand) {

--- a/Sources/Subjects/ReplaySubject.swift
+++ b/Sources/Subjects/ReplaySubject.swift
@@ -72,6 +72,9 @@ public final class ReplaySubject<Output, Failure: Error>: Subject {
         }
 
         subscriptions.forEach { $0.forwardCompletionToBuffer(completion) }
+
+        lock.lock()
+        defer { self.lock.unlock() }
         self.subscriptions.removeAll()
     }
 


### PR DESCRIPTION
Hey folks, you may remember my previous PR: https://github.com/CombineCommunity/CombineExt/pull/86

In this I tried to fix a memory leak that we'd identified, however, it seems like this solution caused a different problem that we've only uncovered when updating to 1.5.0.

I'm not 100% of what in our usage caused the issue - it is weirdly only presented in tests -but I've checked that this change both allows the tests in our consuming app to pass and works when the app is running for users.

I've removed the call to `cancel()` and instead clear the subscriptions after they are forwarded a completion. This seems to make sense to me logically, as once a subscriber has received a completion it can't do anything else.

I appreciate however that this is a change that had a problem for a new unknown change. If you aren't sure about this, I can instead revert my original PR. This would bring back the memory leak, but avoid the failing scenario we are seeing