### PR TITLE
Properly cancel upstream work when using Materialize operator.  Closes #108

### DIFF
--- a/Sources/Operators/Materialize.swift
+++ b/Sources/Operators/Materialize.swift
@@ -92,6 +92,7 @@ private extension Publishers.Materialize {
         }
 
         func cancel() {
+            sink?.cancelUpstream()
             sink = nil
         }
     }


### PR DESCRIPTION
This issue is easily reproducible by running the unit test I have added. The materialize operator will block any upstream work from being cancelled. The root cause seems to be due to a reference cycle where upstream has a reference to the sink, and the sink has a reference to upstream.  The cycle resolves after either a) upstream completes, or b) sink kills the upstream.  This is why simply nil'ing out the sink doesn't cancel upstream, because the sink deinit is not called.  