### PR TITLE
Add `enumerated()` operator

### DIFF
--- a/Sources/Operators/Enumerated.swift
+++ b/Sources/Operators/Enumerated.swift
@@ -1,0 +1,64 @@
+#if canImport(Combine)
+import Combine
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+public extension Publisher {
+    /// Enumerates the elements of a publisher.
+    /// - parameter initial: Initial index, default is 0.
+    /// - returns: A publisher that contains tuples of upstream elements and their indexes.
+    func enumerated(initial: Int = 0) -> Publishers.Enumerated<Self> {
+        Publishers.Enumerated(upstream: self, initial: initial)
+    }
+}
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+public extension Publishers {
+    /// A publisher that enumerates the elements of another publisher by combining the index and element into a tuple.
+    struct Enumerated<Upstream: Publisher>: Publisher {
+        public typealias Output = (index: Int, element: Upstream.Output)
+        public typealias Failure = Upstream.Failure
+
+        public let upstream: Upstream
+        public let initial: Int
+
+        public init(upstream: Upstream, initial: Int = 0) {
+            self.upstream = upstream
+            self.initial = initial
+        }
+
+        public func receive<S>(subscriber: S) where S: Subscriber, S.Failure == Failure, S.Input == Output {
+            upstream.subscribe(Inner(publisher: self, downstream: subscriber))
+        }
+    }
+}
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+private extension Publishers.Enumerated {
+    final class Inner<Downstream: Subscriber>: Subscriber
+    where Downstream.Input == Output, Downstream.Failure == Upstream.Failure {
+        private var currentIndex: Int
+        private let downstream: Downstream
+
+        fileprivate init(
+            publisher: Publishers.Enumerated<Upstream>,
+            downstream: Downstream
+        ) {
+            self.currentIndex = publisher.initial
+            self.downstream = downstream
+        }
+
+        func receive(subscription: Subscription) {
+            downstream.receive(subscription: subscription)
+        }
+
+        func receive(_ input: Upstream.Output) -> Subscribers.Demand {
+            defer { currentIndex += 1 }
+            return downstream.receive((index: currentIndex, element: input))
+        }
+
+        func receive(completion: Subscribers.Completion<Upstream.Failure>) {
+            downstream.receive(completion: completion)
+        }
+    }
+}
+#endif

--- a/Tests/EnumeratedTests.swift
+++ b/Tests/EnumeratedTests.swift
@@ -1,0 +1,98 @@
+#if !os(watchOS)
+import Combine
+import CombineExt
+import XCTest
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+final class EnumeratedTests: XCTestCase {
+    private var cancellables = Set<AnyCancellable>()
+
+    override func tearDown() {
+        cancellables.removeAll()
+
+        super.tearDown()
+    }
+
+    func testEnumeratedWithDefaultInitialValueReturnsIndexAndElements() {
+        let source = PassthroughSubject<String, Never>()
+        var output = [(index: Int, element: String)]()
+        var completion: Subscribers.Completion<Never>?
+
+        source.enumerated().sink(
+            receiveCompletion: { completion = $0 },
+            receiveValue: { output.append($0) }
+        ).store(in: &cancellables)
+
+        source.send("1")
+        source.send("2")
+        source.send("3")
+        source.send(completion: .finished)
+
+        XCTAssertEqual(output.map(\.index), [0, 1, 2])
+        XCTAssertEqual(output.map(\.element), ["1", "2", "3"])
+        XCTAssertEqual(completion, .finished)
+    }
+
+    func testEnumeratedWithCustomInitialValueReturnsIndexAndElements() {
+        let initial = 10
+        let source = PassthroughSubject<String, Never>()
+        var output = [(index: Int, element: String)]()
+        var completion: Subscribers.Completion<Never>?
+
+        source.enumerated(initial: initial).sink(
+            receiveCompletion: { completion = $0 },
+            receiveValue: { output.append($0) }
+        ).store(in: &cancellables)
+
+        source.send("1")
+        source.send("2")
+        source.send("3")
+        source.send(completion: .finished)
+
+        XCTAssertEqual(output.map(\.index), [initial, initial + 1, initial + 2])
+        XCTAssertEqual(output.map(\.element), ["1", "2", "3"])
+        XCTAssertEqual(completion, .finished)
+    }
+
+    func testEnumeratedWhenUpstreamFailsReturnsIndexAndElements() {
+        struct MyError: Error, Equatable {
+            let id = UUID()
+        }
+
+        let error = MyError()
+        let source = PassthroughSubject<String, MyError>()
+        var output = [(index: Int, element: String)]()
+        var completion: Subscribers.Completion<MyError>?
+
+        source.enumerated().sink(
+            receiveCompletion: { completion = $0 },
+            receiveValue: { output.append($0) }
+        ).store(in: &cancellables)
+
+        source.send("1")
+        source.send("2")
+        source.send("3")
+        source.send(completion: .failure(error))
+
+        XCTAssertEqual(output.map(\.index), [0, 1, 2])
+        XCTAssertEqual(output.map(\.element), ["1", "2", "3"])
+        XCTAssertEqual(completion, .failure(error))
+    }
+
+    func testEnumeratedWhenUpstreamHasNoElementsReturnsNoElements() {
+        let source = PassthroughSubject<String, Never>()
+        var output = [(index: Int, element: String)]()
+        var completion: Subscribers.Completion<Never>?
+
+        source.enumerated().sink(
+            receiveCompletion: { completion = $0 },
+            receiveValue: { output.append($0) }
+        ).store(in: &cancellables)
+
+        source.send(completion: .finished)
+
+        XCTAssert(output.isEmpty)
+        XCTAssertEqual(completion, .finished)
+    }
+}
+#endif


### PR DESCRIPTION
Added `enumerated()` operator similar to the one from [RxSwift](https://github.com/ReactiveX/RxSwift/blob/1a1fa37b0d08e0f99ffa41f98f340e8bc60c35c4/RxSwift/Observables/Enumerated.swift) and from [Swift](https://developer.apple.com/documentation/swift/array/1687832-enumerated).