### PR TITLE
Fix of ShareReplay operator for sequential run

### DIFF
--- a/Tests/ShareReplayTests.swift
+++ b/Tests/ShareReplayTests.swift
@@ -241,5 +241,36 @@ final class ShareReplayTests: XCTestCase {
         XCTAssertEqual(completions, [.finished])
         XCTAssertNil(weakSource)
     }
+
+    func testSequentialUpstreamWithShareReplay() {
+        let publisher = Just(1)
+            .eraseToAnyPublisher()
+            .share(replay: 1)
+
+        var valueReceived = false
+        var finishedReceived = false
+
+        Publishers.Zip(publisher, publisher)
+            .sink(
+                receiveCompletion: { completion in
+                    switch completion {
+                    case .finished:
+                        finishedReceived = true
+                    case let .failure(error):
+                        XCTFail("Unexpected completion - failure: \(error).")
+                    }
+                },
+                receiveValue: { leftValue, rightValue in
+                    XCTAssertEqual(leftValue, 1)
+                    XCTAssertEqual(rightValue, 1)
+
+                    valueReceived = true
+                }
+            )
+            .store(in: &subscriptions)
+
+        XCTAssertTrue(valueReceived)
+        XCTAssertTrue(finishedReceived)
+    }
 }
 #endif


### PR DESCRIPTION
**PROBLEM** (Open issue: https://github.com/CombineCommunity/CombineExt/issues/115)

The `share(replay:)` operator freezes when the upstream publisher runs sequentially. 
Following operations are called in this order:
1) `receive(subscriber:)` - replays buffer to the subscriber. At this point the buffer is empty since it has not received any values from the upstream publisher yet.
2) The sequential upstream sends its values. If `Just("random-value")` is used as an upstream publisher, it emits single value and finished event. The subject receives those via `send(_:)` and `send(completion:)` and forwards them to the subscriber. At this time `request(demand:)` has not yet been called on the subscriber. Demand is `zero` and thus the values are not received by the subscriber. 
3) `forwardCompletionToBuffer(_:)` is called on subscriber after `send(completion:)` is received on the subject. It calls `cancel()` which cancels the subscriber. The subscriber does not receive any values and finishes prematurely. 

**FIX** 

The replaying of the values happen only after the `request(demand:)` is called on the subscriber and thus the subscriber is ready to receive values. 
The `cancel()` on the subscriber is called only after the `request(demand:)` is called on the subscriber and thus the subscriber actually has a chance to receive values before being cancelled. 







