### PR TITLE
⚠️ Fix `map(to:)` name collision

### DIFF
--- a/Sources/Operators/MapTo.swift
+++ b/Sources/Operators/MapTo.swift
@@ -14,8 +14,8 @@ public extension Publisher {
     /// Replace each upstream value with a constant.
     ///
     /// - Parameter value: The constant with which to replace each upstream value.
-    /// - Returns: A new publisher wrapping the upstream, but with output type `Result`.
-    func map<Result>(to value: Result) -> Publishers.Map<Self, Result> {
+    /// - Returns: A new publisher wrapping the upstream, but with output type `Value`.
+    func mapToValue<Value>(_ value: Value) -> Publishers.Map<Self, Value> {
         map { _ in value }
     }
 }

--- a/Sources/Operators/MapToValue.swift
+++ b/Sources/Operators/MapToValue.swift
@@ -1,5 +1,5 @@
 //
-//  MapTo.swift
+//  MapToValue.swift
 //  CombineExt
 //
 //  Created by Dan Halliday on 08/05/2022.

--- a/Tests/MapToTests.swift
+++ b/Tests/MapToTests.swift
@@ -29,6 +29,57 @@ final class MapToTests: XCTestCase {
         XCTAssertEqual(result, 2)
     }
 
+    func testMapToWithMultipleElements() {
+        let expectation = XCTestExpectation()
+        expectation.expectedFulfillmentCount = 3
+
+        let subject = PassthroughSubject<Int, Never>()
+
+        subscription = subject
+            .mapToValue("hello")
+            .sink { element in
+                XCTAssertEqual(element, "hello")
+                expectation.fulfill()
+            }
+
+        subject.send(1)
+        subject.send(2)
+        subject.send(1)
+
+        wait(for: [expectation], timeout: 3)
+    }
+
+    func testMapToVoidType() {
+        let expectation = XCTestExpectation()
+        let subject = PassthroughSubject<Int, Never>()
+
+        subscription = subject
+            .mapToValue(Void())
+            .sink { element in
+                XCTAssertTrue(type(of: element) == Void.self)
+
+                expectation.fulfill()
+            }
+
+        subject.send(1)
+
+        wait(for: [expectation], timeout: 3)
+    }
+
+    func testMapToOptionalType() {
+        let subject = PassthroughSubject<Int, Never>()
+        let value: String? = nil
+
+        var result: String? = nil
+
+        subscription = subject
+            .mapToValue(value)
+            .sink(receiveValue: { result = $0 })
+
+        subject.send(1)
+        XCTAssertEqual(result, nil)
+    }
+
     /// Checks if regular map functions complies and works as expected.
     func testMapNameCollision() {
         let fooSubject = PassthroughSubject<Int, Never>()

--- a/Tests/MapToTests.swift
+++ b/Tests/MapToTests.swift
@@ -22,7 +22,7 @@ final class MapToTests: XCTestCase {
         var result: Int? = nil
 
         subscription = subject
-            .map(to: 2)
+            .mapToValue(2)
             .sink(receiveValue: { result = $0 })
 
         subject.send(1)

--- a/Tests/MapToTests.swift
+++ b/Tests/MapToTests.swift
@@ -89,7 +89,7 @@ final class MapToTests: XCTestCase {
 
         let combinedPublisher = Publishers.CombineLatest(fooSubject, barSubject)
             .map { fooItem, barItem in
-                return fooItem * barItem
+                fooItem * barItem
             }
 
         subscription = combinedPublisher

--- a/Tests/MapToTests.swift
+++ b/Tests/MapToTests.swift
@@ -28,5 +28,28 @@ final class MapToTests: XCTestCase {
         subject.send(1)
         XCTAssertEqual(result, 2)
     }
+
+    /// Checks if regular map functions complies and works as expected.
+    func testMapNameCollision() {
+        let fooSubject = PassthroughSubject<Int, Never>()
+        let barSubject = PassthroughSubject<Int, Never>()
+
+        var result: String? = nil
+
+        let combinedPublisher = Publishers.CombineLatest(fooSubject, barSubject)
+            .map { fooItem, barItem in
+                return fooItem * barItem
+            }
+
+        subscription = combinedPublisher
+            .map {
+                "\($0)"
+            }
+            .sink(receiveValue: { result = $0 })
+
+        fooSubject.send(5)
+        barSubject.send(6)
+        XCTAssertEqual(result, "30")
+    }
 }
 #endif

--- a/Tests/MapToValueTests.swift
+++ b/Tests/MapToValueTests.swift
@@ -1,5 +1,5 @@
 //
-//  MapToTests.swift
+//  MapToValueTests.swift
 //  CombineExt
 //
 //  Created by Dan Halliday on 08/05/2022.
@@ -14,7 +14,7 @@ import Combine
 import CombineExt
 
 @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-final class MapToTests: XCTestCase {
+final class MapToValueTests: XCTestCase {
     private var subscription: AnyCancellable!
 
     func testMapToConstantValue() {


### PR DESCRIPTION
Hello everyone!

After the latest update `1.6.0` our project that uses `CombineExt` stopped compiling with a wired error message. After some digging, I figured out that in some cases Swift confuses `map(to:)` extension with `map` operator and uses closure as a constant itself.

It can be reproduced with a test case that I added:
```swift
let fooSubject = PassthroughSubject<Int, Never>()
let barSubject = PassthroughSubject<Int, Never>()

let combinedPublisher = Publishers.CombineLatest(fooSubject, barSubject)
   .map { fooItem, barItem in
       fooItem * barItem // Error here: "ambiguous use of operator '*'"
   }
// adding .eraseToAnyPublisher() will produce AnyPublisher<(Int, Int) -> Int, Never>

_ = combinedPublisher
    .map {
        "\($0)"
     }
     .sink {  
         print($0)
     }

fooSubject.send(5)
barSubject.send(6)
```

One possible solution is to rename this operator to `mapToValue`. This both makes sense semantically, fixes name collision, and is very similar to `mapToResult`.
Also, added more tests for updated `mapToValue` ✨

> ⚠️ Note: this is a breaking change, but it fixes a critical issue.

This is my first PR to CombineExt, please let me know what you think! ✌️