### PR TITLE
Add `mapToVoid` operator

### DIFF
--- a/Sources/Operators/MapToValue.swift
+++ b/Sources/Operators/MapToValue.swift
@@ -18,5 +18,12 @@ public extension Publisher {
     func mapToValue<Value>(_ value: Value) -> Publishers.Map<Self, Value> {
         map { _ in value }
     }
+
+    /// Replace each upstream value with Void.
+    ///
+    /// - Returns: A new publisher wrapping the upstream and replacing each element with Void.
+    func mapToVoid() -> Publishers.Map<Self, Void> {
+        mapToValue(())
+    }
 }
 #endif

--- a/Sources/Operators/MapToValue.swift
+++ b/Sources/Operators/MapToValue.swift
@@ -23,7 +23,7 @@ public extension Publisher {
     ///
     /// - Returns: A new publisher wrapping the upstream and replacing each element with Void.
     func mapToVoid() -> Publishers.Map<Self, Void> {
-        mapToValue(())
+        map { _ in () }
     }
 }
 #endif


### PR DESCRIPTION
After [fixing](https://github.com/CombineCommunity/CombineExt/pull/128) a `mapToValue` operator I got an idea to add `mapToVoid` operator. It's the most common use case for mapping publisher to a constant value. For example if you subscribe to `NotificationCenter` publisher and do not care about the value it produces:

```swift
NotificationCenter.default.publisher(for: UIApplication.userDidTakeScreenshotNotification)
    .mapToVoid()
   .sink {
       // Do something
   }
```