### PR TITLE
combineLatest & zip: make scalable using divide-and-conquer.

### DIFF
--- a/Sources/Operators/CombineLatestMany.swift
+++ b/Sources/Operators/CombineLatestMany.swift
@@ -46,13 +46,10 @@ public extension Collection where Element: Publisher {
     /// - returns: A type-erased publisher with value events from each of the inner publishers `combineLatest`’d
     /// together in an array.
     func combineLatest() -> AnyPublisher<[Element.Output], Element.Failure> {
-        if isEmpty { return Empty().eraseToAnyPublisher() }
-
         var wrapped = map { $0.map { [$0] }.eraseToAnyPublisher() }
         while wrapped.count > 1 {
             wrapped = makeCombinedQuads(input: wrapped)
         }
-
         return wrapped.first?.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()
     }
 }

--- a/Sources/Operators/CombineLatestMany.swift
+++ b/Sources/Operators/CombineLatestMany.swift
@@ -48,31 +48,53 @@ public extension Collection where Element: Publisher {
     func combineLatest() -> AnyPublisher<[Element.Output], Element.Failure> {
         if isEmpty { return Empty().eraseToAnyPublisher() }
 
-        // Given an array of publishers, return an array of the result of combineLatest'ing each successive foursome of
-        // input publishers (or fewer, for the remainder of count%4).
-        func makeCombinedQuads(input: [AnyPublisher<[Element.Output], Element.Failure>]) -> [AnyPublisher<[Element.Output], Element.Failure>] {
-            sequence(state: input.makeIterator(), next: { it in it.next().map { ($0, it.next(), it.next(), it.next()) } })
-            .map { quad in
-                guard let second = quad.1 else { return quad.0 }
-                guard let third = quad.2 else { return quad.0.combineLatest(second)
-                        .map { $0.0 + $0.1 }
-                        .eraseToAnyPublisher()
-                }
-                guard let fourth = quad.3 else { return quad.0.combineLatest(second, third)
-                        .map { $0.0 + $0.1 + $0.2 }
-                        .eraseToAnyPublisher()
-                }
-                return quad.0.combineLatest(second, third, fourth)
-                    .map { $0.0 + $0.1 + $0.2 + $0.3 }
-                    .eraseToAnyPublisher()
-            }
-        }
-
         var wrapped = map { $0.map { [$0] }.eraseToAnyPublisher() }
         while wrapped.count > 1 {
             wrapped = makeCombinedQuads(input: wrapped)
         }
-        return wrapped[0].eraseToAnyPublisher()
+
+        return wrapped.first?.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()
+    }
+}
+
+// MARK: - Private helpers
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+/// CombineLatest an array of input publishers in four-somes.
+///
+/// - parameter input: An array of publishers
+private func makeCombinedQuads<Output, Failure: Swift.Error>(
+    input: [AnyPublisher<[Output], Failure>]
+) -> [AnyPublisher<[Output], Failure>] {
+    // Iterate over the array of input publishers in steps of four
+    sequence(
+        state: input.makeIterator(),
+        next: { it in it.next().map { ($0, it.next(), it.next(), it.next()) } }
+    )
+    .map { quad in
+        // Only one publisher
+        guard let second = quad.1 else { return quad.0 }
+
+        // Two publishers
+        guard let third = quad.2 else {
+            return quad.0
+                .combineLatest(second)
+                .map { $0.0 + $0.1 }
+                .eraseToAnyPublisher()
+        }
+
+        // Three publishers
+        guard let fourth = quad.3 else {
+            return quad.0
+                .combineLatest(second, third)
+                .map { $0.0 + $0.1 + $0.2 }
+                .eraseToAnyPublisher()
+        }
+
+        // Four publishers
+        return quad.0
+            .combineLatest(second, third, fourth)
+            .map { $0.0 + $0.1 + $0.2 + $0.3 }
+            .eraseToAnyPublisher()
     }
 }
 #endif

--- a/Sources/Operators/CombineLatestMany.swift
+++ b/Sources/Operators/CombineLatestMany.swift
@@ -18,17 +18,9 @@ public extension Publisher {
     ///
     /// - returns: A type-erased publisher with value events from `self` and each of the inner publishers `combineLatest`’d
     /// together in an array.
-    func combineLatest<Others: Collection>(with others: Others)
-        -> AnyPublisher<[Output], Failure>
-        where Others.Element: Publisher, Others.Element.Output == Output, Others.Element.Failure == Failure {
-        let seed = map { [$0] }.eraseToAnyPublisher()
-
-        return others.reduce(seed) { combined, next in
-            combined
-                .combineLatest(next)
-                .map { $0 + [$1] }
-                .eraseToAnyPublisher()
-        }
+    func combineLatest<Others: Collection>(with others: Others) -> AnyPublisher<[Output], Failure>
+        where Others.Element == Self, Others.Element.Output == Output, Others.Element.Failure == Failure {
+            ([self] + others).combineLatest()
     }
 
     /// Projects `self` and a `Collection` of `Publisher`s onto a type-erased publisher that chains `combineLatest` calls on
@@ -38,9 +30,7 @@ public extension Publisher {
     ///
     /// - returns: A type-erased publisher with value events from `self` and each of the inner publishers `combineLatest`’d
     /// together in an array.
-    func combineLatest<Other: Publisher>(with others: Other...)
-        -> AnyPublisher<[Output], Failure>
-        where Other.Output == Output, Other.Failure == Failure {
+    func combineLatest(with others: Self...) -> AnyPublisher<[Output], Failure> {
         combineLatest(with: others)
     }
 }
@@ -53,19 +43,33 @@ public extension Collection where Element: Publisher {
     /// - returns: A type-erased publisher with value events from each of the inner publishers `combineLatest`’d
     /// together in an array.
     func combineLatest() -> AnyPublisher<[Element.Output], Element.Failure> {
-        switch count {
-        case 0:
-            return Empty().eraseToAnyPublisher()
-        case 1:
-            return self[startIndex]
-                .combineLatest(with: [Element]())
-        default:
-            let first = self[startIndex]
-            let others = self[index(after: startIndex)...]
+        if isEmpty { return Empty().eraseToAnyPublisher() }
 
-            return first
-                .combineLatest(with: others)
+        // Given an array of publishers, return an array of the result of combineLatest'ing each successive foursome of
+        // input publishers (or fewer, for the remainder of count%4).
+        func makeCombinedQuads(input: [AnyPublisher<[Element.Output], Element.Failure>]) -> [AnyPublisher<[Element.Output], Element.Failure>] {
+            sequence(state: input.makeIterator(), next: { it in it.next().map { ($0, it.next(), it.next(), it.next()) } })
+            .map { quad in
+                guard let second = quad.1 else { return quad.0 }
+                guard let third = quad.2 else { return quad.0.combineLatest(second)
+                        .map { $0.0 + $0.1 }
+                        .eraseToAnyPublisher()
+                }
+                guard let fourth = quad.3 else { return quad.0.combineLatest(second, third)
+                        .map { $0.0 + $0.1 + $0.2 }
+                        .eraseToAnyPublisher()
+                }
+                return quad.0.combineLatest(second, third, fourth)
+                    .map { $0.0 + $0.1 + $0.2 + $0.3 }
+                    .eraseToAnyPublisher()
+            }
         }
+
+        var wrapped = map { $0.map { [$0] }.eraseToAnyPublisher() }
+        while wrapped.count > 1 {
+            wrapped = makeCombinedQuads(input: wrapped)
+        }
+        return wrapped[0].eraseToAnyPublisher()
     }
 }
 #endif

--- a/Sources/Operators/CombineLatestMany.swift
+++ b/Sources/Operators/CombineLatestMany.swift
@@ -18,19 +18,22 @@ public extension Publisher {
     ///
     /// - returns: A type-erased publisher with value events from `self` and each of the inner publishers `combineLatest`’d
     /// together in an array.
-    func combineLatest<Others: Collection>(with others: Others) -> AnyPublisher<[Output], Failure>
-        where Others.Element == Self, Others.Element.Output == Output, Others.Element.Failure == Failure {
-            ([self] + others).combineLatest()
+    func combineLatest<Others: Collection>(with others: Others)
+        -> AnyPublisher<[Output], Failure>
+        where Others.Element: Publisher, Others.Element.Output == Output, Others.Element.Failure == Failure {
+        ([self.eraseToAnyPublisher()] + others.map { $0.eraseToAnyPublisher() }).combineLatest()
     }
 
     /// Projects `self` and a `Collection` of `Publisher`s onto a type-erased publisher that chains `combineLatest` calls on
     /// the inner publishers. This is a variadic overload on Combine’s variants that top out at arity three.
-	///
+    ///
     /// - parameter others: A `Collection`-worth of other publishers with matching output and failure types to combine with.
     ///
     /// - returns: A type-erased publisher with value events from `self` and each of the inner publishers `combineLatest`’d
     /// together in an array.
-    func combineLatest(with others: Self...) -> AnyPublisher<[Output], Failure> {
+    func combineLatest<Other: Publisher>(with others: Other...)
+        -> AnyPublisher<[Output], Failure>
+        where Other.Output == Output, Other.Failure == Failure {
         combineLatest(with: others)
     }
 }

--- a/Sources/Operators/ZipMany.swift
+++ b/Sources/Operators/ZipMany.swift
@@ -20,12 +20,13 @@ public extension Publisher {
     /// - returns: A type-erased publisher with value events from each of the inner publishers zipped together in an array.
     func zip<Others: Collection>(with others: Others)
         -> AnyPublisher<[Output], Failure>
-    where Others.Element == Self, Others.Element.Output == Output, Others.Element.Failure == Failure {
-            ([self] + others).zip()
+        where Others.Element: Publisher, Others.Element.Output == Output, Others.Element.Failure == Failure {
+        ([self.eraseToAnyPublisher()] + others.map { $0.eraseToAnyPublisher() }).zip()
     }
 
     /// A variadic overload on `Publisher.zip(with:)`.
-    func zip(with others: Self...) -> AnyPublisher<[Output], Failure> {
+    func zip<Other: Publisher>(with others: Other...)
+        -> AnyPublisher<[Output], Failure> where Other.Output == Output, Other.Failure == Failure {
         zip(with: others)
     }
 }

--- a/Sources/Operators/ZipMany.swift
+++ b/Sources/Operators/ZipMany.swift
@@ -42,31 +42,51 @@ public extension Collection where Element: Publisher {
     func zip() -> AnyPublisher<[Element.Output], Element.Failure> {
         if isEmpty { return Empty().eraseToAnyPublisher() }
 
-        // Given an array of publishers, return an array of the result of zip'ing each successive foursome of
-        // input publishers (or fewer, for the remainder of count%4).
-        func makeZippedQuads(input: [AnyPublisher<[Element.Output], Element.Failure>]) -> [AnyPublisher<[Element.Output], Element.Failure>] {
-            sequence(state: input.makeIterator(), next: { it in it.next().map { ($0, it.next(), it.next(), it.next()) } })
-            .map { quad in
-                guard let second = quad.1 else { return quad.0 }
-                guard let third = quad.2 else { return quad.0.zip(second)
-                        .map { $0.0 + $0.1 }
-                        .eraseToAnyPublisher()
-                }
-                guard let fourth = quad.3 else { return quad.0.zip(second, third)
-                        .map { $0.0 + $0.1 + $0.2 }
-                        .eraseToAnyPublisher()
-                }
-                return quad.0.zip(second, third, fourth)
-                    .map { $0.0 + $0.1 + $0.2 + $0.3 }
-                    .eraseToAnyPublisher()
-            }
-        }
-
         var wrapped = map { $0.map { [$0] }.eraseToAnyPublisher() }
         while wrapped.count > 1 {
             wrapped = makeZippedQuads(input: wrapped)
         }
-        return wrapped[0].eraseToAnyPublisher()
+        return wrapped.first?.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()
+    }
+}
+
+// MARK: - Private helper
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+/// Zip an array of input publishers in four-somes.
+///
+/// - parameter input: An array of publishers
+private func makeZippedQuads<Output, Failure: Swift.Error>(
+    input: [AnyPublisher<[Output], Failure>]
+) -> [AnyPublisher<[Output], Failure>] {
+    sequence(
+        state: input.makeIterator(),
+        next: { it in it.next().map { ($0, it.next(), it.next(), it.next()) } }
+    )
+    .map { quad in
+        // Only one publisher
+        guard let second = quad.1 else { return quad.0 }
+
+        // Two publishers
+        guard let third = quad.2 else {
+            return quad.0
+                .zip(second)
+                .map { $0.0 + $0.1 }
+                .eraseToAnyPublisher()
+        }
+
+        // Three publishers
+        guard let fourth = quad.3 else {
+            return quad.0
+                .zip(second, third)
+                .map { $0.0 + $0.1 + $0.2 }
+                .eraseToAnyPublisher()
+        }
+
+        // Four publishers
+        return quad.0
+            .zip(second, third, fourth)
+            .map { $0.0 + $0.1 + $0.2 + $0.3 }
+            .eraseToAnyPublisher()
     }
 }
 #endif

--- a/Sources/Operators/ZipMany.swift
+++ b/Sources/Operators/ZipMany.swift
@@ -40,8 +40,6 @@ public extension Collection where Element: Publisher {
     ///
     /// - returns: A type-erased publisher with value events from each of the inner publishers zipped together in an array.
     func zip() -> AnyPublisher<[Element.Output], Element.Failure> {
-        if isEmpty { return Empty().eraseToAnyPublisher() }
-
         var wrapped = map { $0.map { [$0] }.eraseToAnyPublisher() }
         while wrapped.count > 1 {
             wrapped = makeZippedQuads(input: wrapped)

--- a/Tests/CombineLatestManyTests.swift
+++ b/Tests/CombineLatestManyTests.swift
@@ -195,5 +195,20 @@ final class CombineLatestManyTests: XCTestCase {
 
         XCTAssertEqual(results, [[1, 2, 3, 4, 5], [1, 6, 3, 4, 5]])
     }
+
+    func testCombineLatestAtScale() {
+        // Using a combineLatest implementation that combines first/the-rest triggers a stack overflow using 1e5
+        // publishers, but the divide-and-conquer implementation gets through 1e7 just fine (though the test takes
+        // 28s to complete on an M1 Pro).
+        let numPublishers = Int(1e5 + 1) // +1 to minimize the odds that numPublishers%4==0 matters.
+
+        let publishers = Array(repeating: 1, count: numPublishers)
+            .map { _ in Just(2) }
+        var results = [[Int]]()
+        subscription = publishers.combineLatest()
+            .sink(receiveValue: { results.append($0) })
+        let wantAllTwos = Array(repeating: 2, count: numPublishers)
+        XCTAssertEqual(results, [wantAllTwos])
+    }
 }
 #endif

--- a/Tests/ZipManyTests.swift
+++ b/Tests/ZipManyTests.swift
@@ -209,5 +209,17 @@ final class ZipManyTests: XCTestCase {
         XCTAssertTrue(results.isEmpty)
         XCTAssertTrue(completed)
     }
+
+    func testZipAtScale() {
+        let numPublishers = Int(1e5 + 1) // +1 to minimize the odds that numPublishers%4==0 matters.
+
+        let publishers = Array(repeating: 1, count: numPublishers)
+            .map { _ in Just(2) }
+        var results = [[Int]]()
+        subscription = publishers.zip()
+            .sink(receiveValue: { results.append($0) })
+        let wantAllTwos = Array(repeating: 2, count: numPublishers)
+        XCTAssertEqual(results, [wantAllTwos])
+    }
 }
 #endif


### PR DESCRIPTION
Previously combineLatest's implementation would trigger a stack overflow on 15000
publishers because the implementation combined its inputs linearly.
This commit replaces that with repeated (hierarchical) 4-way merges,
which lets the same scaled test scenario go to 1e7 publishers with no
issues (other than taking 28s to run the test on my M1 Pro, hence the
choice to commit the test with only 1e5 publishers). Test execution
wall-time scales linearly with publisher count.

Re: "4-way merge":
- Why not use a higher value? 4 is the highest arity offered by
  Combine's Publisher.combineLatest.
- Why not use a lower value? Using 2-way merges instead of 4-way still
  lets the 1e7 test case pass, but is ~60% slower (1e7 publishers take
  45s insted of 28s).

All of the above applies remarkably similarly to zip, also changed in the same way in this PR.