### PR TITLE
Fix ReplaySubject race condition

### DIFF
--- a/Sources/Subjects/ReplaySubject.swift
+++ b/Sources/Subjects/ReplaySubject.swift
@@ -89,21 +89,15 @@ public final class ReplaySubject<Output, Failure: Error>: Subject {
             self?.completeSubscriber(withIdentifier: subscriberIdentifier)
         }
 
-        let buffer: [Output]
-        let completion: Subscribers.Completion<Failure>?
-
         do {
             lock.lock()
             defer { lock.unlock() }
 
+            subscription.replay(buffer, completion: completion)
             subscriptions.append(subscription)
-
-            buffer = self.buffer
-            completion = self.completion
         }
 
         subscriber.receive(subscription: subscription)
-        subscription.replay(buffer, completion: completion)
     }
 
     private func completeSubscriber(withIdentifier subscriberIdentifier: CombineIdentifier) {


### PR DESCRIPTION
The ReplaySubject currently adds a new subscription before replaying the buffer. Since these two steps are not synchronized by the lock, it is possible that a new value is sent to the new subscription before the new subscription finishes replaying the buffer. This can result in a new subscription to a ReplaySubject receiving values out of order.

To fix this, it should be safe to have the new subscription replay the buffer before being added to the collection of subscriptions. The new subscription's DemandBuffer will have no requested demand at this point, so it will hold onto the replayed values until demand is requested. Once the lock is unlocked, any new values will be sent to all the subscriptions, which will always be added to the demand buffer after the replayed values.

I tried to keep the footprint of the new test minimal, but let me know if additional comments or helper methods could make it more clear.