### PR TITLE
Fix memory leak in WithLatestFrom

### DIFF
--- a/Sources/Operators/WithLatestFrom.swift
+++ b/Sources/Operators/WithLatestFrom.swift
@@ -234,6 +234,8 @@ private extension Publishers.WithLatestFrom {
         sink = nil
         otherSubscription?.cancel()
     }
+      
+    deinit { cancel() }
   }
 }
 #endif


### PR DESCRIPTION
Resolves #139 

The withLatestFrom stream has been completed, but it has been confirmed that `otherSubscription` is remaining and causing memory leaks.
Modified it to call `cancel` when `WithLatestFrom`'s `Subscription` is deinitialized.