### PR TITLE
Allow editing the value property of the CurrentValueRelay

### DIFF
--- a/Sources/Relays/CurrentValueRelay.swift
+++ b/Sources/Relays/CurrentValueRelay.swift
@@ -17,7 +17,11 @@ import Combine
 /// - note: Unlike PassthroughRelay, CurrentValueRelay maintains a buffer of the most recently published value.
 @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public class CurrentValueRelay<Output>: Relay {
-    public var value: Output { storage.value }
+    public var value: Output {
+        get { storage.value }
+        set { storage.value = newValue }
+    }
+    
     private let storage: CurrentValueSubject<Output, Never>
     private var subscriptions = [Subscription<CurrentValueSubject<Output, Never>,
                                               AnySubscriber<Output, Never>>]()


### PR DESCRIPTION
I would like to be able to edit the value property of the CurrentValueRelay, as is possible for CurrentValueSubject