### PR TITLE
Yet Another Fix for RetryWhen

### DIFF
--- a/Sources/Common/DemandBuffer.swift
+++ b/Sources/Common/DemandBuffer.swift
@@ -33,7 +33,17 @@ class DemandBuffer<S: Subscriber> {
     init(subscriber: S) {
         self.subscriber = subscriber
     }
-
+    
+    /// Signal to the buffer that the upstream has changed
+    /// - Returns: A demand that has already been requested from the previous upstream, but has not yet been processed
+    func attachToNewUpstream() -> Subscribers.Demand {
+        lock.lock()
+        defer { lock.unlock() }
+        
+        demandState.sent = demandState.requested
+        return demandState.requested - demandState.processed
+    }
+    
     /// Buffer an upstream value to later be forwarded to
     /// the downstream subscriber, once it demands it
     ///

--- a/Sources/Common/Sink.swift
+++ b/Sources/Common/Sink.swift
@@ -62,7 +62,13 @@ class Sink<Upstream: Publisher, Downstream: Subscriber>: Subscriber {
     }
 
     func receive(subscription: Subscription) {
-        upstreamSubscription = subscription
+        defer { upstreamSubscription = subscription }
+        
+        if let upstreamSubscription {
+            upstreamSubscription.cancel()
+            let newDemand = buffer.attachToNewUpstream()
+            subscription.requestIfNeeded(newDemand)
+        }
     }
 
     func receive(_ input: Upstream.Output) -> Subscribers.Demand {

--- a/Sources/Operators/RetryWhen.swift
+++ b/Sources/Operators/RetryWhen.swift
@@ -89,6 +89,9 @@ extension Publishers.RetryWhen {
         }
 
         func cancel() {
+            cancellable?.cancel()
+            cancellable = nil
+            sink?.cancelUpstream()
             sink = nil
         }
     }

--- a/Tests/RetryWhenTests.swift
+++ b/Tests/RetryWhenTests.swift
@@ -71,7 +71,93 @@ class RetryWhenTests: XCTestCase {
         XCTAssertEqual(completion, .finished)
         XCTAssertEqual(times, 2)
     }
+    
+    func testSuccessfulRetryWithManyRetries() {
+        var times = 0
+        var retriesCount = 0
+        var subscriptionsCount = 0
+        var cancelCount = 0
+        var resultOutput: [Int] = []
+        var completion: Subscribers.Completion<RetryWhenTests.MyError>?
 
+        subscription = Deferred(createPublisher: { () -> AnyPublisher<Int, MyError> in
+            defer { times += 1 }
+            if times == 0 {
+                return Fail<Int, MyError>(error: MyError.someError).eraseToAnyPublisher()
+            } else {
+                return Just(times)
+                    .setFailureType(to: MyError.self)
+                    .handleEvents(
+                        receiveSubscription: { _ in subscriptionsCount += 1 },
+                        receiveCancel: { cancelCount += 1 }
+                    )
+                    .eraseToAnyPublisher()
+            }
+        })
+        .retryWhen { error in
+            return error
+                .handleEvents(receiveOutput: { _ in
+                    retriesCount += 1
+                })
+                .flatMapLatest { _ in [1, 2].publisher }
+        }
+        .sink(
+            receiveCompletion: { completion = $0 },
+            receiveValue: { resultOutput.append($0) }
+        )
+
+        XCTAssertEqual(resultOutput, [2])
+        XCTAssertEqual(completion, .finished)
+        XCTAssertEqual(times, 3)
+        XCTAssertEqual(retriesCount, 1)
+        XCTAssertEqual(subscriptionsCount, 2)
+        XCTAssertEqual(cancelCount, 1)
+    }
+    
+    func testSuccessfulRetryWithCustomDemand() {
+        var times = 0
+        var retriesCount = 0
+        var resultOutput: [Int] = []
+        var completion: Subscribers.Completion<RetryWhenTests.MyError>?
+        
+        AnyPublisher<Int, MyError>.init { subscriber in
+            defer { times += 1 }
+            if times < 2 {
+                subscriber.send(times)
+                subscriber.send(completion: .failure(MyError.someError))
+            }
+            else {
+                subscriber.send(times)
+                subscriber.send(completion: .finished)
+            }
+            
+            return AnyCancellable({})
+        }
+        .retryWhen { error in
+            error
+                .handleEvents(receiveOutput: { _ in retriesCount += 1})
+                .map { _ in }
+        }
+        .subscribe(
+            AnySubscriber(
+                receiveSubscription: { subscription in
+                    self.subscription = AnyCancellable { subscription.cancel() }
+                    subscription.request(.max(3))
+                },
+                receiveValue: {
+                    resultOutput.append($0)
+                    return .none
+                },
+                receiveCompletion: { completion = $0 }
+            )
+        )
+
+        XCTAssertEqual(resultOutput, [0, 1, 2])
+        XCTAssertEqual(completion, .finished)
+        XCTAssertEqual(times, 3)
+        XCTAssertEqual(retriesCount, 2)
+    }
+    
     func testRetryFailure() {
         var expectedOutput: Int?
 


### PR DESCRIPTION
Continuation of [Update testSuccessfulRetry and code to make it pass. #150](https://github.com/CombineCommunity/CombineExt/pull/150)

### First commit
1. When **RetryWhen** changes upstream to **Sink**, the subscription to the previous upstream must be canceled in order not to receive unnecessary events.
2. You also need to re-request from the new upstream demand, which was not received from the previous upstream.

### Second commit
Adds tests for both cases described above

### Third commit
Added explicit cancellation of subscriptions in the `cancel()` method call. Because `deinit` on **Sink** can be called after a while, forcing the publisher to work.
This causes a lot of problems when using **RetryWhen** in cells of collections or tables, where the `cancel()` method can be called very often and the `deinit` call on **Sink** can occur after a few tens of seconds.