### PR TITLE
Add sample(with:) and sample(on:) operators

### DIFF
--- a/Sources/Operators/WithLatestFrom.swift
+++ b/Sources/Operators/WithLatestFrom.swift
@@ -112,6 +112,38 @@ public extension Publisher {
     where Other.Failure == Failure, Other1.Failure == Failure, Other2.Failure == Failure {
      withLatestFrom(other, other1, other2) { $1 }
   }
+
+  /// Merge two publishers into a single publisher that emits the latest value from `self`
+  /// along with the latest value from `sampler` only when `sampler` emits.
+  ///
+  /// Emits from `sampler` will be ignored until `self` has emitted a value at least once.
+  ///
+  /// - Parameters:
+  ///   - sampler: A second publisher source.
+  ///   - resultSelector: Function invoked for each sampling with sampler and sampled value.
+  ///
+  /// - Returns: A publisher containing the result of combining the latest value of `self`
+  ///            with the latest value from `sampler` only when `sampler`
+  ///            emits a value, using the specified result selector function.
+  func sample<Sampler: Publisher, Result>(
+      with sampler: Sampler,
+      resultSelector: @escaping (Sampler.Output, Output) -> Result
+  ) -> Publishers.WithLatestFrom<Sampler, Self, Result> {
+      .init(upstream: sampler, second: self, resultSelector: resultSelector)
+  }
+
+  /// Merge two publishers into a single publisher that emits the latest value from `self` whenever `sampler` emits.
+  ///
+  /// Emits from `sampler` will be ignored until `self` has emitted a value at least once.
+  ///
+  /// - Parameter sampler: A second publisher source.
+  ///
+  /// - Returns: A publisher that will emit the latest value of `self` whenever `sampler` emits.
+  func sample<Sampler: Publisher>(
+      on sampler: Sampler
+  ) -> Publishers.WithLatestFrom<Sampler, Self, Self.Output> {
+      sample(with: sampler) { _, sampledValue in sampledValue }
+  }
 }
 
 // MARK: - Publisher

--- a/Tests/WithLatestFromTests.swift
+++ b/Tests/WithLatestFromTests.swift
@@ -604,5 +604,84 @@ class WithLatestFromTests: XCTestCase {
         XCTAssertNil(weakSubject3)
         XCTAssertNil(weakSubject4)
     }
+
+    func testSampleWith() {
+        let samplee = PassthroughSubject<Int, Never>()
+        let sampler = PassthroughSubject<String, Never>()
+        var results = [String]()
+        var completed = false
+
+        subscription = samplee
+            .sample(with: sampler) { "\($0)\($1)" }
+            .sink(receiveCompletion: { _ in completed  = true },
+                  receiveValue: { results.append($0) }
+            )
+
+        sampler.send("kek")
+        samplee.send(1)
+        samplee.send(2)
+        samplee.send(3)
+        sampler.send("bar")
+        samplee.send(4)
+        samplee.send(5)
+        sampler.send("foo")
+        samplee.send(6)
+        sampler.send("qux")
+        samplee.send(7)
+        samplee.send(8)
+        samplee.send(9)
+
+        XCTAssertEqual(results, [
+            "bar3",
+            "foo5",
+            "qux6",
+        ])
+
+        XCTAssertFalse(completed)
+        samplee.send(completion: .finished)
+        XCTAssertFalse(completed)
+        sampler.send(completion: .finished)
+        XCTAssertTrue(completed)
+    }
+
+    func testSampleOn() {
+        let samplee = PassthroughSubject<Int, Never>()
+        let sampler = PassthroughSubject<String, Never>()
+        var results = [Int]()
+        var completed = false
+
+        subscription = samplee
+            .sample(on: sampler)
+            .sink(receiveCompletion: { _ in completed  = true },
+                  receiveValue: { results.append($0) }
+            )
+
+        sampler.send("kek")
+        samplee.send(1)
+        samplee.send(2)
+        samplee.send(3)
+        sampler.send("bar")
+        samplee.send(4)
+        samplee.send(5)
+        sampler.send("foo")
+        samplee.send(6)
+        sampler.send("qux")
+        samplee.send(7)
+        samplee.send(8)
+        samplee.send(9)
+
+        XCTAssertEqual(results, [
+            3,
+            5,
+            6,
+        ])
+
+        XCTAssertFalse(completed)
+        samplee.send(completion: .finished)
+        XCTAssertFalse(completed)
+        sampler.send(completion: .finished)
+        XCTAssertTrue(completed)
+        subscription.cancel()
+    }
 }
 #endif


### PR DESCRIPTION
A suggestion for adding the `sample(with:)` and `sample:(on)` operators as seen in [ReactiveSwift](https://reactivecocoa.io/reactiveswift/docs/latest/Classes/Signal.html#/s:13ReactiveSwift6SignalC6sample4withACyx_qd__tq_GACyqd__s5NeverOG_tlF). Essentially a convenient reverse of `withLatestFrom`. 