### PR TITLE
Feat: add an extension to subscribe a KeyValuePath to a Publisher

### DIFF
--- a/CombineExt.xcodeproj/project.pbxproj
+++ b/CombineExt.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		63FEBC9527E9FE9000E934AD /* FlatMapFirstTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63FEBC9427E9FE9000E934AD /* FlatMapFirstTests.swift */; };
 		712E36C82711B79000A2AAFE /* RetryWhen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712E36C72711B79000A2AAFE /* RetryWhen.swift */; };
 		7182326F26DAAF230026BAD3 /* RetryWhenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7182326E26DAAF230026BAD3 /* RetryWhenTests.swift */; };
+		973A87492A15FC2A00CBD6D2 /* KeyValueCodingAndObservingSubscribing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 973A87482A15FC2A00CBD6D2 /* KeyValueCodingAndObservingSubscribing.swift */; };
 		BF330EF924F20032001281FC /* Timer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF330EF824F20032001281FC /* Timer.swift */; };
 		BF330EFB24F20080001281FC /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF330EFA24F20080001281FC /* Lock.swift */; };
 		BF3D3B5D253B83F300D830ED /* IgnoreFailure.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF3D3B5C253B83F300D830ED /* IgnoreFailure.swift */; };
@@ -124,6 +125,7 @@
 		63FEBC9427E9FE9000E934AD /* FlatMapFirstTests.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = FlatMapFirstTests.swift; sourceTree = "<group>"; };
 		712E36C72711B79000A2AAFE /* RetryWhen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RetryWhen.swift; sourceTree = "<group>"; };
 		7182326E26DAAF230026BAD3 /* RetryWhenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryWhenTests.swift; sourceTree = "<group>"; };
+		973A87482A15FC2A00CBD6D2 /* KeyValueCodingAndObservingSubscribing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyValueCodingAndObservingSubscribing.swift; sourceTree = "<group>"; };
 		BF330EF824F20032001281FC /* Timer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Timer.swift; sourceTree = "<group>"; };
 		BF330EFA24F20080001281FC /* Lock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
 		BF3D3B5C253B83F300D830ED /* IgnoreFailure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IgnoreFailure.swift; sourceTree = "<group>"; };
@@ -243,6 +245,7 @@
 			isa = PBXGroup;
 			children = (
 				OBJ_12 /* Optional.swift */,
+				973A87482A15FC2A00CBD6D2 /* KeyValueCodingAndObservingSubscribing.swift */,
 			);
 			path = Convenience;
 			sourceTree = "<group>";
@@ -636,6 +639,7 @@
 				OBJ_89 /* Dematerialize.swift in Sources */,
 				OBJ_90 /* FlatMapLatest.swift in Sources */,
 				OBJ_91 /* MapMany.swift in Sources */,
+				973A87492A15FC2A00CBD6D2 /* KeyValueCodingAndObservingSubscribing.swift in Sources */,
 				712E36C82711B79000A2AAFE /* RetryWhen.swift in Sources */,
 				EA0D86CF287D19CC0085356E /* MapToResult.swift in Sources */,
 				1970A8AA25246FBD00799AB6 /* FilterMany.swift in Sources */,

--- a/Sources/Convenience/KeyValueCodingAndObservingSubscribing.swift
+++ b/Sources/Convenience/KeyValueCodingAndObservingSubscribing.swift
@@ -16,12 +16,12 @@ protocol KeyValueCodingAndObservingSubscribing: AnyObject where Self : Objective
 extension KeyValueCodingAndObservingSubscribing {
 
     /// A method to subscribe a KeyValuePath to a Publisher.
-    func subscribe<P: Publisher, Value>(at keyPath: ReferenceWritableKeyPath<Self, Value>, to publisher: P) -> AnyCancellable where P.Output == Value, P.Failure == Never {
-        subscribe(at: keyPath, to: publisher, on: RunLoop.main)
+    func subscribe<P: Publisher, Value>(_ keyPath: ReferenceWritableKeyPath<Self, Value>, to publisher: P) -> AnyCancellable where P.Output == Value, P.Failure == Never {
+        subscribe(keyPath, to: publisher, on: RunLoop.main)
     }
 
     /// A method to subscribe a KeyValuePath to a Publisher.
-    func subscribe<P: Publisher, S: Scheduler, Value>(at keyPath: ReferenceWritableKeyPath<Self, Value>, to publisher: P, on scheduler: S) -> AnyCancellable where P.Output == Value, P.Failure == Never {
+    func subscribe<P: Publisher, S: Scheduler, Value>(_ keyPath: ReferenceWritableKeyPath<Self, Value>, to publisher: P, on scheduler: S) -> AnyCancellable where P.Output == Value, P.Failure == Never {
         
         publisher
             .receive(on: scheduler)

--- a/Sources/Convenience/KeyValueCodingAndObservingSubscribing.swift
+++ b/Sources/Convenience/KeyValueCodingAndObservingSubscribing.swift
@@ -1,0 +1,37 @@
+//
+//  KeyValueCodingAndObservingSubscribing.swift
+//  CombineExt
+//
+//  Created by Andrea Altea on 18/05/23.
+//
+
+#if canImport(Combine)
+import Foundation
+import Combine
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+protocol KeyValueCodingAndObservingSubscribing: AnyObject where Self : ObjectiveC.NSObject { }
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension KeyValueCodingAndObservingSubscribing {
+
+    /// A method to subscribe a KeyValuePath to a Publisher.
+    func subscribe<P: Publisher, Value>(at keyPath: ReferenceWritableKeyPath<Self, Value>, to publisher: P) -> AnyCancellable where P.Output == Value, P.Failure == Never {
+        subscribe(at: keyPath, to: publisher, on: RunLoop.main)
+    }
+
+    /// A method to subscribe a KeyValuePath to a Publisher.
+    func subscribe<P: Publisher, S: Scheduler, Value>(at keyPath: ReferenceWritableKeyPath<Self, Value>, to publisher: P, on scheduler: S) -> AnyCancellable where P.Output == Value, P.Failure == Never {
+        
+        publisher
+            .receive(on: scheduler)
+            .sink { [weak self] value in
+                self?[keyPath: keyPath] = value
+            }
+    }
+}
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension NSObject: KeyValueCodingAndObservingSubscribing { }
+
+#endif


### PR DESCRIPTION
Maybe someone could find this interesting? 
Just a way to subscribe a KeyValue path to a publisher in one line, having the possibility also to specify the Scheduler that you want to use.

Just an use example:
```swift
    let titleRelay = CurrentValueRelay("Await")
    awaitLabel
        .subscribe(\.text, to: titleRelay)
        .store(in: &cancellables)
```