### PR TITLE
Add codable conformance to Event

### DIFF
--- a/Sources/Models/Event.swift
+++ b/Sources/Models/Event.swift
@@ -15,6 +15,10 @@ public enum Event<Output, Failure: Swift.Error> {
     case finished
 }
 
+// MARK: - Codable Conformance
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension Event: Codable where Output: Codable, Failure: Codable {}
+
 // MARK: - Equatable Conformance
 @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Event: Equatable where Output: Equatable, Failure: Equatable {


### PR DESCRIPTION
Only when `Output` and `Failure` are both also `Codable`