### PR TITLE
#165: Rename generic parameter from S to T to avoid shadowing generic parameter of outer scope

### DIFF
--- a/Sources/Operators/Internal/Timer.swift
+++ b/Sources/Operators/Internal/Timer.swift
@@ -161,10 +161,10 @@
           lock.cleanupLock()
         }
 
-        func addSubscriber<S: Subscriber>(_ sub: S)
+        func addSubscriber<T: Subscriber>(_ sub: T)
         where
-          S.Failure == Failure,
-          S.Input == Output
+          T.Failure == Failure,
+          T.Input == Output
         {
           lock.lock()
           subscribers.append(AnySubscriber(sub))
@@ -229,8 +229,8 @@
         }
       }
 
-      internal func receive<S: Subscriber>(subscriber: S)
-      where Failure == S.Failure, Output == S.Input {
+      internal func receive<T: Subscriber>(subscriber: T)
+      where Failure == T.Failure, Output == T.Input {
         routingSubscription.addSubscriber(subscriber)
       }
 


### PR DESCRIPTION
This PR fixes [issue #165](https://github.com/CombineCommunity/CombineExt/issues/165).