### PR TITLE
Fix memory leak issue with PassthroughRelay

### DIFF
--- a/Sources/Relays/PassthroughRelay.swift
+++ b/Sources/Relays/PassthroughRelay.swift
@@ -78,8 +78,9 @@ private extension PassthroughRelay {
         }
 
         func forceFinish() {
-            sink?.shouldForwardCompletion = true
-            sink?.receive(completion: .finished)
+            self.sink?.shouldForwardCompletion = true
+            self.sink?.receive(completion: .finished)
+            self.sink = nil
         }
 
         func request(_ demand: Subscribers.Demand) {
@@ -87,7 +88,7 @@ private extension PassthroughRelay {
         }
 
         func cancel() {
-            sink = nil
+            forceFinish()
         }
     }
 }

--- a/Sources/Relays/PassthroughRelay.swift
+++ b/Sources/Relays/PassthroughRelay.swift
@@ -78,9 +78,9 @@ private extension PassthroughRelay {
         }
 
         func forceFinish() {
-            self.sink?.shouldForwardCompletion = true
-            self.sink?.receive(completion: .finished)
-            self.sink = nil
+            sink?.shouldForwardCompletion = true
+            sink?.receive(completion: .finished)
+            sink = nil
         }
 
         func request(_ demand: Subscribers.Demand) {


### PR DESCRIPTION
Fixed a memory leak with `PassthroughRelay` as described in this [issue #167](https://github.com/CombineCommunity/CombineExt/issues/167).

It appears that `PassthroughRelay` fails to release its subscriptions upon receiving completion, as similarly described in this [PR #85](https://github.com/CombineCommunity/CombineExt/issues/85).

I've confirmed the disappearance of the retain cycle with this solution in my project, but I'm not fully proficient with Combine. So, Any comments or suggestions would be greatly appreciated. 